### PR TITLE
placeholder feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,14 @@ name = "ratatui_minimal"
 required-features = ["ratatui-crossterm"]
 
 [[example]]
+name = "ratatui_placepop"
+required-features = ["ratatui-crossterm"]
+
+[[example]]
+name = "placepop"
+required-features = ["crossterm"]
+
+[[example]]
 name = "ratatui_editor"
 required-features = ["ratatui-crossterm", "search"]
 

--- a/examples/placepop.rs
+++ b/examples/placepop.rs
@@ -1,0 +1,64 @@
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use std::io;
+use tui::backend::CrosstermBackend;
+use tui::layout::Rect;
+use tui::style::{Color, Style};
+use tui::widgets::{Block, Borders};
+use tui::Terminal;
+use tui_textarea::{Input, Key, TextArea};
+
+fn main() -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    enable_raw_mode()?;
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut term = Terminal::new(backend)?;
+
+    let mut textarea = TextArea::default();
+    textarea.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::LightBlue))
+            .title("Crossterm Popup Example"),
+    );
+
+    let area = Rect {
+        width: 40,
+        height: 5,
+        x: 5,
+        y: 5,
+    };
+    textarea.set_style(Style::default().fg(Color::Yellow));
+
+    // set placeholder
+
+    textarea.set_placeholder_style(Style::default());
+    textarea.set_placeholder("prompt message".to_string());
+    loop {
+        term.draw(|f| {
+            f.render_widget(textarea.widget(), area);
+        })?;
+        match crossterm::event::read()?.into() {
+            Input { key: Key::Esc, .. } => break,
+            input => {
+                textarea.input(input);
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    crossterm::execute!(
+        term.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    term.show_cursor()?;
+
+    println!("Lines: {:?}", textarea.lines());
+    Ok(())
+}

--- a/examples/ratatui_placepop.rs
+++ b/examples/ratatui_placepop.rs
@@ -1,0 +1,62 @@
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm_026 as crossterm;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders};
+use ratatui::Terminal;
+use std::io;
+use tui_textarea::{Input, Key, TextArea};
+
+fn main() -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    enable_raw_mode()?;
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut term = Terminal::new(backend)?;
+
+    let mut textarea = TextArea::default();
+    textarea.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::LightBlue))
+            .title("Crossterm Popup Example"),
+    );
+
+    let area = Rect {
+        width: 40,
+        height: 5,
+        x: 5,
+        y: 5,
+    };
+    textarea.set_style(Style::default().fg(Color::Yellow));
+    textarea.set_placeholder_style(Style::default());
+    textarea.set_placeholder("prompt message".to_string());
+    loop {
+        term.draw(|f| {
+            f.render_widget(textarea.widget(), area);
+        })?;
+        match crossterm::event::read()?.into() {
+            Input { key: Key::Esc, .. } => break,
+            input => {
+                textarea.input(input);
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    crossterm::execute!(
+        term.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    term.show_cursor()?;
+
+    println!("Lines: {:?}", textarea.lines());
+    Ok(())
+}

--- a/examples/single_line.rs
+++ b/examples/single_line.rs
@@ -37,6 +37,7 @@ fn main() -> io::Result<()> {
 
     let mut textarea = TextArea::default();
     textarea.set_cursor_line_style(Style::default());
+    textarea.set_placeholder("enter a valid float, eg 1.56".to_string());
     let layout =
         Layout::default().constraints([Constraint::Length(3), Constraint::Min(1)].as_slice());
     let mut is_valid = validate(&mut textarea);

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -50,6 +50,8 @@ pub struct TextArea<'a> {
     #[cfg(feature = "search")]
     search: Search,
     alignment: Alignment,
+    pub(crate) placeholder: Option<String>,
+    pub(crate) placeholder_style: Option<Style>,
 }
 
 /// Convert any iterator whose elements can be converted into [`String`] into [`TextArea`]. Each [`String`] element is
@@ -147,6 +149,8 @@ impl<'a> TextArea<'a> {
             #[cfg(feature = "search")]
             search: Search::default(),
             alignment: Alignment::Left,
+            placeholder: None,
+            placeholder_style: None,
         }
     }
 
@@ -1223,6 +1227,14 @@ impl<'a> TextArea<'a> {
         self.line_number_style
     }
 
+    /// sets the placeholder text
+    pub fn set_placeholder(&mut self, placeholder: String) {
+        self.placeholder = Some(placeholder);
+    }
+
+    pub fn set_placeholder_style(&mut self, style: Style) {
+        self.placeholder_style = Some(style);
+    }
     /// Set the style of cursor. By default, a cursor is rendered in the reversed color. Setting the same style as
     /// cursor line hides a cursor.
     /// ```


### PR DESCRIPTION
in order to cleanly integrate tui-textarea into another tool (gitui https://github.com/extrawurst/gitui) I need this feature.

It is like the html input tag placeholder feature, text is displayed dimmed in the input box as a hint of what to enter. Once text is entered the hint is removed

![placeholder](https://user-images.githubusercontent.com/489231/235313549-4fad6336-bf48-40f6-a577-c7d7884f9732.gif)


I had to slightly modify how the text and its surrounding block are displayed. it is very tricky to get precise control. over the text style of the paragraph and its containing block otherwise. I placed a link to the discussion about this topic with ratatui team. https://github.com/tui-rs-revival/ratatui/issues/144

I added 2 samples of a popup dialog with the new feature. I also added it to the single_line sample as that seemed a good fit

