### PR TITLE
fix windows double character

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tui = { version = "0.19", default-features = false, optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 crossterm-026 = { package = "crossterm", version = "0.26", optional = true }
 ratatui = { version = "0.20.1", default-features = false, optional = true }
+log = "0.4.17"
 
 [[example]]
 name = "minimal"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,10 +1,12 @@
 #[cfg(any(feature = "crossterm", feature = "ratatui-crossterm"))]
 use crate::crossterm::event::{
-    Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseEvent as CrosstermMouseEvent,
-    MouseEventKind as CrosstermMouseEventKind,
+    Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+    MouseEvent as CrosstermMouseEvent, MouseEventKind as CrosstermMouseEventKind,
 };
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
+#[cfg(any(feature = "crossterm", feature = "ratatui-crossterm"))]
+use log::trace;
 #[cfg(any(feature = "termion", feature = "ratatui-termion"))]
 use termion::event::{Event as TermionEvent, Key as TermionKey, MouseEvent as TermionMouseEvent};
 
@@ -99,8 +101,9 @@ impl Default for Input {
 impl From<CrosstermEvent> for Input {
     /// Convert [`crossterm::event::Event`] to [`Input`].
     fn from(event: CrosstermEvent) -> Self {
+        trace!("Cross Event:{:?}", event);
         match event {
-            CrosstermEvent::Key(key) => Self::from(key),
+            CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => Self::from(key),
             CrosstermEvent::Mouse(mouse) => Self::from(mouse),
             _ => Self::default(),
         }


### PR DESCRIPTION
fix for https://github.com/rhysd/tui-textarea/issues/14

a change in crossterm 0.26 (https://github.com/crossterm-rs/crossterm/pull/745) causes key release event to be generated on windows. The input handler of textarea was treating those as additional keystrokes. The same bug was apparent in all the samples

Note I also added some logging. I did not remove it as the plumbing is useful to have (I think)