### PR TITLE
bump `ratatui` version and fix some Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,7 @@ repository = "https://github.com/rhysd/tui-textarea"
 readme = "README.md"
 categories = ["text-editors", "text-processing"]
 keywords = ["tui", "textarea", "editor", "input", "edit", "ratatui"]
-include = [
-    "/src",
-    "/examples",
-    "/README.md",
-    "/LICENSE.txt",
-]
+include = ["/src", "/examples", "/README.md", "/LICENSE.txt"]
 
 [features]
 default = ["crossterm"]
@@ -41,7 +36,7 @@ termion = { version = "1.5", optional = true }
 tui = { version = "0.19", default-features = false, optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 crossterm-026 = { package = "crossterm", version = "0.26", optional = true }
-ratatui = { version = "0.20.1", default-features = false, optional = true }
+ratatui = { version = "0.22.0", default-features = false, optional = true }
 
 [[example]]
 name = "minimal"
@@ -84,9 +79,7 @@ name = "ratatui_termion"
 required-features = ["ratatui-termion"]
 
 [workspace]
-members = [
-    "bench",
-]
+members = ["bench"]
 
 [profile.bench]
 lto = "thin"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -332,14 +332,14 @@ mod tests {
         use crate::tui::widgets::Widget;
         use crate::{CursorMove, TextArea};
 
-        let mut textarea: TextArea = (0..20).into_iter().map(|i| i.to_string()).collect();
+        let mut textarea: TextArea = (0..20).map(|i| i.to_string()).collect();
         let r = Rect {
             x: 0,
             y: 0,
             width: 24,
             height: 8,
         };
-        let mut b = Buffer::empty(r.clone());
+        let mut b = Buffer::empty(r);
         textarea.widget().render(r, &mut b);
 
         textarea.move_cursor(CursorMove::Bottom);

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -191,14 +191,14 @@ mod tests {
         use crate::tui::widgets::Widget;
         use crate::TextArea;
 
-        let mut textarea: TextArea = (0..20).into_iter().map(|i| i.to_string()).collect();
+        let mut textarea: TextArea = (0..20).map(|i| i.to_string()).collect();
         let r = Rect {
             x: 0,
             y: 0,
             width: 24,
             height: 8,
         };
-        let mut b = Buffer::empty(r.clone());
+        let mut b = Buffer::empty(r);
         textarea.widget().render(r, &mut b);
 
         textarea.scroll(Scrolling::Delta { rows: 2, cols: 0 });

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -1609,14 +1609,14 @@ mod tests {
         use crate::tui::layout::Rect;
         use crate::tui::widgets::Widget;
 
-        let mut textarea: TextArea = (0..20).into_iter().map(|i| i.to_string()).collect();
+        let mut textarea: TextArea = (0..20).map(|i| i.to_string()).collect();
         let r = Rect {
             x: 0,
             y: 0,
             width: 24,
             height: 8,
         };
-        let mut b = Buffer::empty(r.clone());
+        let mut b = Buffer::empty(r);
         textarea.widget().render(r, &mut b);
 
         textarea.scroll((15, 0));


### PR DESCRIPTION
Ratatui support is broken due to an outdated dependency version. This fixes that.