### PR TITLE
fix hard tab display

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -18,6 +18,8 @@ fn main() -> io::Result<()> {
     let mut term = Terminal::new(backend)?;
 
     let mut textarea = TextArea::default();
+    textarea.set_hard_tab_indent(true);
+    textarea.set_tab_length(4);
     textarea.set_block(
         Block::default()
             .borders(Borders::ALL)

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -18,8 +18,6 @@ fn main() -> io::Result<()> {
     let mut term = Terminal::new(backend)?;
 
     let mut textarea = TextArea::default();
-    textarea.set_hard_tab_indent(true);
-    textarea.set_tab_length(4);
     textarea.set_block(
         Block::default()
             .borders(Borders::ALL)

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -67,14 +67,14 @@ fn prepare_line(s: &str, tab_len: u8, mask: Option<char>) -> Cow<'_, str> {
                     if c == '\t' {
                         buf.reserve(s.len());
                         buf.push_str(&s[..i]);
-                        let len = tab_len as usize - (col % tab_len as usize) as usize;
+                        let len = tab_len as usize - (col % tab_len as usize);
                         buf.push_str(&tab[..len]);
                         col += len;
                     } else {
                         col += 1;
                     }
                 } else if c == '\t' {
-                    let len = tab_len as usize - (col % tab_len as usize) as usize;
+                    let len = tab_len as usize - (col % tab_len as usize);
                     buf.push_str(&tab[..len]);
                     col += len;
                 } else {

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -61,17 +61,25 @@ fn prepare_line(s: &str, tab_len: u8, mask: Option<char>) -> Cow<'_, str> {
         None => {
             let tab = spaces(tab_len);
             let mut buf = String::new();
+            let mut col: usize = 0;
             for (i, c) in s.char_indices() {
                 if buf.is_empty() {
                     if c == '\t' {
                         buf.reserve(s.len());
                         buf.push_str(&s[..i]);
-                        buf.push_str(tab);
+                        let len = tab_len as usize - (col % tab_len as usize) as usize;
+                        buf.push_str(&tab[..len]);
+                        col += len;
+                    } else {
+                        col += 1;
                     }
                 } else if c == '\t' {
-                    buf.push_str(tab);
+                    let len = tab_len as usize - (col % tab_len as usize) as usize;
+                    buf.push_str(&tab[..len]);
+                    col += len;
                 } else {
                     buf.push(c);
+                    col += 1;
                 }
             }
             if !buf.is_empty() {


### PR DESCRIPTION
hard tabs always insert 4 spaces

heres is minimal example switched to hard tab mode by adding
`textarea.set_hard_tab_indent(true);`

![image](https://github.com/rhysd/tui-textarea/assets/489231/4c7bfbe5-2b1c-4998-812d-dd6356cbaeec)

this is the result of typing
 - `a,tab,b,return`
 - `aa,tab,b,return`
 - `aaa,tab,b,return`

the bs should be aligned, they are not


