### PR TITLE
Fixed some spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ let mut textarea = TextArea::from([
 
 // Create `TextArea` from `String`
 let mut text: String = ...;
-let mut textarea = TextARea::from(text.lines());
+let mut textarea = TextArea::from(text.lines());
 ```
 
 `TextArea` also implements `FromIterator<impl Into<String>>`. `Iterator::collect()` can collect strings as an editor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(all(feature = "ratatui", feature = "tuirs"))]
-compile_error!("ratatui support and tui-rs support are exclussive. only one of them can be enabled at the same time. see https://github.com/rhysd/tui-textarea#installation");
+compile_error!("ratatui support and tui-rs support are exclusive. only one of them can be enabled at the same time. see https://github.com/rhysd/tui-textarea#installation");
 
 mod cursor;
 mod highlight;

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -1345,7 +1345,7 @@ impl<'a> TextArea<'a> {
         self.mask = None;
     }
 
-    /// Get the charater to mask text. When no character is set, `None` is returned.
+    /// Get the character to mask text. When no character is set, `None` is returned.
     /// ```
     /// use tui_textarea::TextArea;
     ///


### PR DESCRIPTION
I found some spelling mistakes using [`typos`](https://github.com/crate-ci/typos). This PR only contains the corrections for those spelling mistakes, not any instrumentation to integrate `typos` e.g. into the CI pipeline. If you would like that, I can look into it and create a separate PR.