### PR TITLE
implement select

### DIFF
--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -265,6 +265,7 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g' | 'n'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Down, .. } => {
                         if !textarea.search_forward(false) {
@@ -275,11 +276,13 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g'),
                         ctrl: false,
                         alt: true,
+                        ..
                     }
                     | Input {
                         key: Key::Char('p'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Up, .. } => {
                         if !textarea.search_back(false) {

--- a/examples/tuirs_editor.rs
+++ b/examples/tuirs_editor.rs
@@ -267,6 +267,7 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g' | 'n'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Down, .. } => {
                         if !textarea.search_forward(false) {
@@ -277,11 +278,13 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g'),
                         ctrl: false,
                         alt: true,
+                        ..
                     }
                     | Input {
                         key: Key::Char('p'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Up, .. } => {
                         if !textarea.search_back(false) {

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -10,10 +10,12 @@ use std::iter;
 use tui::text::Spans as Line;
 use unicode_width::UnicodeWidthChar as _;
 
+#[derive(Debug)]
 enum Boundary {
     Cursor(Style),
     #[cfg(feature = "search")]
     Search(Style),
+    Select(Style),
     End,
 }
 
@@ -21,9 +23,10 @@ impl Boundary {
     fn cmp(&self, other: &Boundary) -> Ordering {
         fn rank(b: &Boundary) -> u8 {
             match b {
-                Boundary::Cursor(_) => 2,
+                Boundary::Cursor(_) => 3,
                 #[cfg(feature = "search")]
                 Boundary::Search(_) => 1,
+                Boundary::Select(_) => 2,
                 Boundary::End => 0,
             }
         }
@@ -36,43 +39,59 @@ impl Boundary {
             #[cfg(feature = "search")]
             Boundary::Search(s) => Some(*s),
             Boundary::End => None,
+            Boundary::Select(s) => Some(*s),
         }
     }
 }
 
-fn line_display_text(s: &str, tab_len: u8, mask: Option<char>) -> Cow<'_, str> {
-    if let Some(ch) = mask {
-        // No tab character processing in the mask case
-        let masked = iter::repeat(ch).take(s.chars().count()).collect();
-        return Cow::Owned(masked);
-    }
+struct DisplayTextBuilder {
+    tab_len: u8,
+    width: usize,
+    mask: Option<char>,
+}
 
-    let tab = spaces(tab_len);
-    let mut buf = String::new();
-    let mut width = 0;
-    for (i, c) in s.char_indices() {
-        if c == '\t' {
-            if buf.is_empty() {
-                buf.reserve(s.len());
-                buf.push_str(&s[..i]);
-            }
-            if tab_len > 0 {
-                let len = tab_len as usize - (width % tab_len as usize);
-                buf.push_str(&tab[..len]);
-                width += len;
-            }
-        } else {
-            if !buf.is_empty() {
-                buf.push(c);
-            }
-            width += c.width().unwrap_or(0);
+impl DisplayTextBuilder {
+    fn new(tab_len: u8, mask: Option<char>) -> Self {
+        Self {
+            tab_len,
+            width: 0,
+            mask,
         }
     }
 
-    if !buf.is_empty() {
-        Cow::Owned(buf)
-    } else {
-        Cow::Borrowed(s)
+    fn build<'s>(&mut self, s: &'s str) -> Cow<'s, str> {
+        if let Some(ch) = self.mask {
+            // Note: We don't need to track width on masking text since width of tab character is fixed
+            let masked = iter::repeat(ch).take(s.chars().count()).collect();
+            return Cow::Owned(masked);
+        }
+
+        let tab = spaces(self.tab_len);
+        let mut buf = String::new();
+        for (i, c) in s.char_indices() {
+            if c == '\t' {
+                if buf.is_empty() {
+                    buf.reserve(s.len());
+                    buf.push_str(&s[..i]);
+                }
+                if self.tab_len > 0 {
+                    let len = self.tab_len as usize - (self.width % self.tab_len as usize);
+                    buf.push_str(&tab[..len]);
+                    self.width += len;
+                }
+            } else {
+                if !buf.is_empty() {
+                    buf.push(c);
+                }
+                self.width += c.width().unwrap_or(0);
+            }
+        }
+
+        if !buf.is_empty() {
+            Cow::Owned(buf)
+        } else {
+            Cow::Borrowed(s)
+        }
     }
 }
 
@@ -85,10 +104,17 @@ pub struct LineHighlighter<'a> {
     cursor_style: Style,
     tab_len: u8,
     mask: Option<char>,
+    select_style: Style,
 }
 
 impl<'a> LineHighlighter<'a> {
-    pub fn new(line: &'a str, cursor_style: Style, tab_len: u8, mask: Option<char>) -> Self {
+    pub fn new(
+        line: &'a str,
+        cursor_style: Style,
+        tab_len: u8,
+        mask: Option<char>,
+        select_style: Style,
+    ) -> Self {
         Self {
             line,
             spans: vec![],
@@ -98,6 +124,7 @@ impl<'a> LineHighlighter<'a> {
             cursor_style,
             tab_len,
             mask,
+            select_style,
         }
     }
 
@@ -105,6 +132,11 @@ impl<'a> LineHighlighter<'a> {
         let pad = spaces(lnum_len - num_digits(row + 1) + 1);
         self.spans
             .push(Span::styled(format!("{}{} ", pad, row + 1), style));
+    }
+
+    pub fn select(&mut self, start: usize, end: usize, style: Style) {
+        self.boundaries.push((Boundary::Select(style), start));
+        self.boundaries.push((Boundary::End, end));
     }
 
     pub fn cursor_line(&mut self, cursor_col: usize, style: Style) {
@@ -138,13 +170,12 @@ impl<'a> LineHighlighter<'a> {
             cursor_style,
             cursor_at_end,
             mask,
+            select_style,
         } = self;
+        let mut builder = DisplayTextBuilder::new(tab_len, mask);
 
         if boundaries.is_empty() {
-            spans.push(Span::styled(
-                line_display_text(line, tab_len, mask),
-                style_begin,
-            ));
+            spans.push(Span::styled(builder.build(line), style_begin));
             if cursor_at_end {
                 spans.push(Span::styled(" ", cursor_style));
             }
@@ -156,92 +187,140 @@ impl<'a> LineHighlighter<'a> {
             o => o,
         });
 
-        let mut boundaries = boundaries.into_iter();
+        // let mut boundaries = boundaries.into_iter();
         let mut style = style_begin;
         let mut start = 0;
         let mut stack = vec![];
-
-        loop {
-            if let Some((next_boundary, end)) = boundaries.next() {
-                if start < end {
-                    spans.push(Span::styled(
-                        line_display_text(&line[start..end], tab_len, mask),
-                        style,
-                    ));
-                }
-
-                style = if let Some(s) = next_boundary.style() {
-                    stack.push(style);
-                    s
+        let mut dont_add_cursor = false;
+        //  trace!("hl boundaries: {:?}", boundaries);
+        for (next_boundary, end) in boundaries {
+            //      trace!("hlb: {:?} {:?}", next_boundary, end);
+            //        trace!("xx {:?} {:?} {} {}", style, select_style, start, end);
+            if start < end {
+                // add extra select space at line end to indicate
+                // that the \n will be deleted / included
+                if end > line.chars().count() && style == select_style {
+                    spans.push(Span::styled(builder.build(&line[start..end - 1]), style));
+                    spans.push(Span::styled(" ", style));
+                    dont_add_cursor = true;
                 } else {
-                    stack.pop().unwrap_or(style_begin)
-                };
-                start = end;
-            } else {
-                if start != line.len() {
-                    spans.push(Span::styled(
-                        line_display_text(&line[start..], tab_len, mask),
-                        style,
-                    ));
+                    spans.push(Span::styled(builder.build(&line[start..end]), style));
                 }
-                if cursor_at_end {
-                    spans.push(Span::styled(" ", cursor_style));
-                }
-                return Line::from(spans);
             }
+
+            style = if let Some(s) = next_boundary.style() {
+                stack.push(style);
+                s
+            } else {
+                stack.pop().unwrap_or(style_begin)
+            };
+            start = end;
         }
+        if start < line.len() {
+            spans.push(Span::styled(builder.build(&line[start..]), style));
+        }
+        if cursor_at_end && !dont_add_cursor {
+            spans.push(Span::styled(" ", cursor_style));
+        }
+
+        Line::from(spans)
     }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unicode_width::UnicodeWidthStr as _;
+
+    fn build(text: &'static str, tab: u8, mask: Option<char>) -> Cow<'static, str> {
+        DisplayTextBuilder::new(tab, mask).build(text)
+    }
+
+    #[track_caller]
+    fn build_with_offset(offset: usize, text: &'static str, tab: u8) -> Cow<'static, str> {
+        let mut b = DisplayTextBuilder::new(tab, None);
+        b.width = offset;
+        let built = b.build(text);
+        let want = offset + built.as_ref().width();
+        assert_eq!(b.width, want, "in={:?}, out={:?}", text, built); // Check post condition
+        built
+    }
 
     #[test]
     #[rustfmt::skip]
     fn test_line_display_text() {
-        assert_eq!(&line_display_text(      "", 0,      None),                  "");
-        assert_eq!(&line_display_text(      "", 4,      None),                  "");
-        assert_eq!(&line_display_text(      "", 8,      None),                  "");
-        assert_eq!(&line_display_text(      "", 0, Some('x')),                  "");
-        assert_eq!(&line_display_text(      "", 4, Some('x')),                  "");
-        assert_eq!(&line_display_text(      "", 8, Some('x')),                  "");
-        assert_eq!(&line_display_text(     "a", 0,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 4,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 8,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 0, Some('x')),                 "x");
-        assert_eq!(&line_display_text(     "a", 4, Some('x')),                 "x");
-        assert_eq!(&line_display_text(     "a", 8, Some('x')),                 "x");
-        assert_eq!(&line_display_text(   "a\t", 0,      None),                 "a");
-        assert_eq!(&line_display_text(   "a\t", 4,      None),              "a   ");
-        assert_eq!(&line_display_text(   "a\t", 8,      None),          "a       ");
-        assert_eq!(&line_display_text(   "a\t", 0, Some('x')),                "xx");
-        assert_eq!(&line_display_text(   "a\t", 4, Some('x')),                "xx");
-        assert_eq!(&line_display_text(   "a\t", 8, Some('x')),                "xx");
-        assert_eq!(&line_display_text(    "\t", 0,      None),                "\t");
-        assert_eq!(&line_display_text(    "\t", 4,      None),              "    ");
-        assert_eq!(&line_display_text(    "\t", 8,      None),          "        ");
-        assert_eq!(&line_display_text(    "\t", 0, Some('x')),                 "x");
-        assert_eq!(&line_display_text(    "\t", 4, Some('x')),                 "x");
-        assert_eq!(&line_display_text(    "\t", 8, Some('x')),                 "x");
-        assert_eq!(&line_display_text(  "a\tb", 0,      None),                "ab");
-        assert_eq!(&line_display_text(  "a\tb", 4,      None),             "a   b");
-        assert_eq!(&line_display_text(  "a\tb", 8,      None),         "a       b");
-        assert_eq!(&line_display_text(  "a\tb", 0, Some('x')),               "xxx");
-        assert_eq!(&line_display_text(  "a\tb", 4, Some('x')),               "xxx");
-        assert_eq!(&line_display_text(  "a\tb", 8, Some('x')),               "xxx");
-        assert_eq!(&line_display_text("a\t\tb", 0,      None),                "ab");
-        assert_eq!(&line_display_text("a\t\tb", 4,      None),         "a       b");
-        assert_eq!(&line_display_text("a\t\tb", 8,      None), "a               b");
-        assert_eq!(&line_display_text("a\t\tb", 0, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("a\t\tb", 4, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("a\t\tb", 8, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("ab\t\t", 0,      None),                "ab");
-        assert_eq!(&line_display_text("ab\t\t", 4,      None),          "ab      ");
-        assert_eq!(&line_display_text("ab\t\t", 8,      None),  "ab              ");
-        assert_eq!(&line_display_text("abcd\t", 4,      None),          "abcd    ");
-        assert_eq!(&line_display_text(  "あ\t", 0,      None),                "あ");
-        assert_eq!(&line_display_text(  "あ\t", 4,      None),              "あ  ");
-        assert_eq!(&line_display_text(  "🐶\t", 4,      None),              "🐶  ");
-        assert_eq!(&line_display_text(  "あ\t", 4, Some('x')),                "xx");
+        assert_eq!(&build(      "",  0,      None),                  "");
+        assert_eq!(&build(      "",  4,      None),                  "");
+        assert_eq!(&build(      "",  8,      None),                  "");
+        assert_eq!(&build(      "",  0, Some('x')),                  "");
+        assert_eq!(&build(      "",  4, Some('x')),                  "");
+        assert_eq!(&build(      "",  8, Some('x')),                  "");
+        assert_eq!(&build(     "a",  0,      None),                 "a");
+        assert_eq!(&build(     "a",  4,      None),                 "a");
+        assert_eq!(&build(     "a",  8,      None),                 "a");
+        assert_eq!(&build(     "a",  0, Some('x')),                 "x");
+        assert_eq!(&build(     "a",  4, Some('x')),                 "x");
+        assert_eq!(&build(     "a",  8, Some('x')),                 "x");
+        assert_eq!(&build(   "a\t",  0,      None),                 "a");
+        assert_eq!(&build(   "a\t",  4,      None),              "a   ");
+        assert_eq!(&build(   "a\t",  8,      None),          "a       ");
+        assert_eq!(&build(   "a\t",  0, Some('x')),                "xx");
+        assert_eq!(&build(   "a\t",  4, Some('x')),                "xx");
+        assert_eq!(&build(   "a\t",  8, Some('x')),                "xx");
+        assert_eq!(&build(    "\t",  0,      None),                "\t");
+        assert_eq!(&build(    "\t",  4,      None),              "    ");
+        assert_eq!(&build(    "\t",  8,      None),          "        ");
+        assert_eq!(&build(    "\t",  0, Some('x')),                 "x");
+        assert_eq!(&build(    "\t",  4, Some('x')),                 "x");
+        assert_eq!(&build(    "\t",  8, Some('x')),                 "x");
+        assert_eq!(&build(  "a\tb",  0,      None),                "ab");
+        assert_eq!(&build(  "a\tb",  4,      None),             "a   b");
+        assert_eq!(&build(  "a\tb",  8,      None),         "a       b");
+        assert_eq!(&build(  "a\tb",  0, Some('x')),               "xxx");
+        assert_eq!(&build(  "a\tb",  4, Some('x')),               "xxx");
+        assert_eq!(&build(  "a\tb",  8, Some('x')),               "xxx");
+        assert_eq!(&build("a\t\tb",  0,      None),                "ab");
+        assert_eq!(&build("a\t\tb",  4,      None),         "a       b");
+        assert_eq!(&build("a\t\tb",  8,      None), "a               b");
+        assert_eq!(&build("a\t\tb",  0, Some('x')),              "xxxx");
+        assert_eq!(&build("a\t\tb",  4, Some('x')),              "xxxx");
+        assert_eq!(&build("a\t\tb",  8, Some('x')),              "xxxx");
+        assert_eq!(&build("a\tb\tc", 0,      None),               "abc");
+        assert_eq!(&build("a\tb\tc", 4,      None),         "a   b   c");
+        assert_eq!(&build("a\tb\tc", 8,      None), "a       b       c");
+        assert_eq!(&build("a\tb\tc", 0, Some('x')),             "xxxxx");
+        assert_eq!(&build("a\tb\tc", 4, Some('x')),             "xxxxx");
+        assert_eq!(&build("a\tb\tc", 8, Some('x')),             "xxxxx");
+        assert_eq!(&build("ab\t\t",  0,      None),                "ab");
+        assert_eq!(&build("ab\t\t",  4,      None),          "ab      ");
+        assert_eq!(&build("ab\t\t",  8,      None),  "ab              ");
+        assert_eq!(&build("abcd\t",  4,      None),          "abcd    ");
+        assert_eq!(&build(  "あ\t",  0,      None),                "あ");
+        assert_eq!(&build(  "あ\t",  4,      None),              "あ  ");
+        assert_eq!(&build(  "🐶\t",  4,      None),              "🐶  ");
+        assert_eq!(&build(  "あ\t",  4, Some('x')),                "xx");
+
+        // When the start position of the text is not start of the line (#43)
+        assert_eq!(&build_with_offset(1,         "", 0),           "");
+        assert_eq!(&build_with_offset(1,        "a", 0),          "a");
+        assert_eq!(&build_with_offset(1,       "あ", 0),         "あ");
+        assert_eq!(&build_with_offset(1,       "\t", 4),        "   ");
+        assert_eq!(&build_with_offset(1,      "a\t", 4),        "a  ");
+        assert_eq!(&build_with_offset(1,     "あ\t", 4),        "あ ");
+        assert_eq!(&build_with_offset(2,       "\t", 4),         "  ");
+        assert_eq!(&build_with_offset(2,      "a\t", 4),         "a ");
+        assert_eq!(&build_with_offset(2,     "あ\t", 4),     "あ    ");
+        assert_eq!(&build_with_offset(3,      "a\t", 4),      "a    ");
+        assert_eq!(&build_with_offset(4,       "\t", 4),       "    ");
+        assert_eq!(&build_with_offset(4,      "a\t", 4),       "a   ");
+        assert_eq!(&build_with_offset(4,     "あ\t", 4),       "あ  ");
+        assert_eq!(&build_with_offset(5,       "\t", 4),        "   ");
+        assert_eq!(&build_with_offset(5,      "a\t", 4),        "a  ");
+        assert_eq!(&build_with_offset(5,     "あ\t", 4),        "あ ");
+        assert_eq!(&build_with_offset(2,     "\t\t", 4),     "      ");
+        assert_eq!(&build_with_offset(2,   "a\ta\t", 4),     "a a   ");
+        assert_eq!(&build_with_offset(1, "あ\tあ\t", 4),    "あ あ  ");
+        assert_eq!(&build_with_offset(2, "あ\tあ\t", 4), "あ    あ  ");
     }
+
+    // TODO: Add tests for LineHighlighter
 }

--- a/src/input/crossterm.rs
+++ b/src/input/crossterm.rs
@@ -49,9 +49,15 @@ impl From<KeyEvent> for Input {
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
         let key = Key::from(key.code);
 
-        Self { key, ctrl, alt }
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -72,7 +78,14 @@ impl From<MouseEvent> for Input {
         let key = Key::from(mouse.kind);
         let ctrl = mouse.modifiers.contains(KeyModifiers::CONTROL);
         let alt = mouse.modifiers.contains(KeyModifiers::ALT);
-        Self { key, ctrl, alt }
+        let shift = mouse.modifiers.contains(KeyModifiers::SHIFT);
+
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -90,7 +90,7 @@ impl Default for Key {
 /// textarea.input(Input {
 ///     key: Key::Char('a'),
 ///     ctrl: true,
-///     alt: false,
+///     alt: false,shift:false
 /// });
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Hash)]
@@ -102,6 +102,8 @@ pub struct Input {
     pub ctrl: bool,
     /// Alt modifier key. `true` means Alt key was pressed.
     pub alt: bool,
+    // Shift key.  `true` means Shift key was pressed.
+    pub shift: bool,
 }
 
 #[cfg(test)]
@@ -110,7 +112,12 @@ mod tests {
 
     #[allow(dead_code)]
     pub(crate) fn input(key: Key, ctrl: bool, alt: bool) -> Input {
-        Input { key, ctrl, alt }
+        Input {
+            key,
+            ctrl,
+            alt,
+            shift: false,
+        }
     }
 
     #[test]

--- a/src/input/termion.rs
+++ b/src/input/termion.rs
@@ -17,6 +17,7 @@ impl From<KeyEvent> for Input {
     fn from(key: KeyEvent) -> Self {
         let mut ctrl = false;
         let mut alt = false;
+        let shift = false;
         let key = match key {
             KeyEvent::Char('\n' | '\r') => Key::Enter,
             KeyEvent::Char(c) => Key::Char(c),
@@ -44,7 +45,12 @@ impl From<KeyEvent> for Input {
             _ => Key::Null,
         };
 
-        Input { key, ctrl, alt }
+        Input {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -71,6 +77,7 @@ impl From<MouseEvent> for Input {
             key,
             ctrl: false,
             alt: false,
+            shift: false,
         }
     }
 }

--- a/src/input/termwiz.rs
+++ b/src/input/termwiz.rs
@@ -46,8 +46,13 @@ impl From<KeyEvent> for Input {
         let key = Key::from(key);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -77,8 +82,13 @@ impl From<MouseEvent> for Input {
         let key = Key::from(mouse_buttons);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -94,8 +104,13 @@ impl From<PixelMouseEvent> for Input {
         let key = Key::from(mouse_buttons);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -862,7 +862,9 @@ impl<'a> TextArea<'a> {
             if yank {
                 self.yank = removed.clone().into();
             };
-            self.push_history(EditKind::DeleteStr(removed, first_start), self.cursor);
+            if delete {
+                self.push_history(EditKind::DeleteStr(removed, first_start), self.cursor);
+            }
             return true;
         };
 
@@ -900,13 +902,14 @@ impl<'a> TextArea<'a> {
         if yank {
             self.yank = YankText::Chunk(deleted.clone());
         };
-
-        let edit = if deleted.len() == 1 {
-            EditKind::DeleteStr(deleted.remove(0), first_start)
-        } else {
-            EditKind::DeleteChunk(deleted, row, first_start)
-        };
-        self.push_history(edit, self.cursor);
+        if delete {
+            let edit = if deleted.len() == 1 {
+                EditKind::DeleteStr(deleted.remove(0), first_start)
+            } else {
+                EditKind::DeleteChunk(deleted, row, first_start)
+            };
+            self.push_history(edit, self.cursor);
+        }
 
         true
     }

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -886,7 +886,12 @@ impl<'a> TextArea<'a> {
             vec![self.lines[row][first_start..].to_string()]
         };
 
-        deleted.extend(self.lines.drain(row + 1..r));
+        if delete {
+            deleted.extend(self.lines.drain(row + 1..r));
+        } else {
+            deleted.extend(self.lines[row + 1..r].iter().map(|s| s.to_string()));
+        }
+
         if row + 1 < self.lines.len() {
             let mut last_line = if delete {
                 let ll = self.lines.remove(row + 1);

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -814,9 +814,8 @@ impl<'a> TextArea<'a> {
     }
 
     // grabs the specified (maybe multi line string)
-    // always placed in history
     // sometimes yanked
-    // sometimes deleted from lines array
+    // sometimes deleted from lines array and placed in history
 
     fn delete_str_internal(&mut self, chars: usize, yank: bool, delete: bool) -> bool {
         if chars == 0 {


### PR DESCRIPTION
second go.

tested with all crossterm/ratatui samples. All work, including search, default select highlight color changed to be different from search highlight. Tested with hard and soft tabs, mask mode. plain ascii and complex chars

Notes. 
 - Changed `delete_str` core as `delete_str_internal` (user visible `delete_str` now calls `delete_str_internal`) to accept flags indicating whether or not to yank and / or delete. Since delete is optional maybe there is a better name. Why no delete sometimes?  ctrlc / copy needs to yank but not delete. Why no yank? If I select some text and then type it overwrites the selected text, so I need to delete, but should not yank (IMO)
 - The main change for users of the API is the inclusion of shift as a modifier in Input, hence the tweaks to a few samples
 - The other change is if they do not use `input` or `input_without_shortcuts` they must call `should_start_selection`. I was wondering about adding a sample for that. None of the current samples need it but I know that the project I work (gitui) on would
 - added ctrl-x cut and ctrl-c copy
 - as far as I can see termion does not propagate the shift key so select does not work with it

 
