### PR TITLE
word wrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ search = ["dep:regex"]
 arbitrary = { version = "1", features = ["derive"], optional = true }
 crossterm = { package = "crossterm", version = "0.27", optional = true }
 crossterm-025 = { package = "crossterm", version = "0.25", optional = true }
+log = "0.4.20"
 ratatui = { version = ">=0.23.0, <1", default-features = false, optional = true }
 regex = { version = "1", optional = true }
 termion = { version = "2.0", optional = true }
@@ -51,6 +52,10 @@ unicode-width = "0.1.11"
 
 [[example]]
 name = "minimal"
+required-features = ["crossterm"]
+
+[[example]]
+name = "wrap_dem"
 required-features = ["crossterm"]
 
 [[example]]
@@ -108,6 +113,9 @@ members = [
 
 [profile.bench]
 lto = "thin"
+
+[dev-dependencies]
+simplelog = "0.12.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -265,6 +265,7 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g' | 'n'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Down, .. } => {
                         if !textarea.search_forward(false) {
@@ -275,11 +276,13 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g'),
                         ctrl: false,
                         alt: true,
+                        ..
                     }
                     | Input {
                         key: Key::Char('p'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Up, .. } => {
                         if !textarea.search_back(false) {

--- a/examples/tuirs_editor.rs
+++ b/examples/tuirs_editor.rs
@@ -267,6 +267,7 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g' | 'n'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Down, .. } => {
                         if !textarea.search_forward(false) {
@@ -277,11 +278,13 @@ impl<'a> Editor<'a> {
                         key: Key::Char('g'),
                         ctrl: false,
                         alt: true,
+                        ..
                     }
                     | Input {
                         key: Key::Char('p'),
                         ctrl: true,
                         alt: false,
+                        ..
                     }
                     | Input { key: Key::Up, .. } => {
                         if !textarea.search_back(false) {

--- a/examples/wrap_dem.rs
+++ b/examples/wrap_dem.rs
@@ -87,13 +87,15 @@ fn main() -> io::Result<()> {
                     ctrl: true,
                     shift: true,
                     alt: false,
-                } => textarea.set_wrap_mode(WrapMode::Word),
+                }
+                | Input { key: Key::F(1), .. } => textarea.set_wrap_mode(WrapMode::Word),
                 Input {
                     key: Key::Char('Z'),
                     ctrl: true,
                     shift: true,
                     alt: false,
-                } => textarea.set_wrap_mode(WrapMode::None),
+                }
+                | Input { key: Key::F(2), .. } => textarea.set_wrap_mode(WrapMode::None),
                 Input {
                     key: Key::Char('F'),
                     ctrl: true,

--- a/examples/wrap_dem.rs
+++ b/examples/wrap_dem.rs
@@ -1,0 +1,123 @@
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture, KeyEventKind};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Terminal;
+use simplelog::*;
+use std::fs::File;
+use std::io;
+use tui_textarea::{trace, Input, Key, TextArea, WrapMode};
+fn main() -> io::Result<()> {
+    CombinedLogger::init(vec![WriteLogger::new(
+        LevelFilter::Info,
+        Config::default(),
+        File::create("my_rust_binary.log").unwrap(),
+    )])
+    .unwrap();
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+
+    enable_raw_mode()?;
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut term = Terminal::new(backend)?;
+
+    let mut textarea = TextArea::default();
+    //textarea.set_line_number_style(Style::default());
+    let title = String::from("Crossterm Minimal Example");
+
+    textarea.set_block(Block::default().borders(Borders::ALL).title(title.as_str()));
+    let mut mouse_pos = String::new();
+    let mut mouse_event = String::new();
+    // let mut draw = true;
+    loop {
+        term.draw(|f| {
+            let t = format!(
+                "Screen {:?} Data: {:?} VP: {:?}\n{}\n{}",
+                textarea.pub_screen_cursor(),
+                textarea.cursor(),
+                textarea.viewport(),
+                mouse_pos,
+                mouse_event
+            );
+            let r = Rect::new(0, 0, f.size().width, 5);
+
+            let para = Paragraph::new(t).block(Block::default().title(""));
+            f.render_widget(para, r);
+
+            let mut rect = f.size();
+            rect.y += 5;
+            rect.height -= 5;
+            f.render_widget(textarea.widget(), rect);
+        })?;
+        match crossterm::event::read()? {
+            crossterm::event::Event::Mouse(me) => {
+                trace!("Mouse: {:?}", me);
+                mouse_event = format!("MouseEvent: {:?}", me);
+                match me.kind {
+                    crossterm::event::MouseEventKind::Moved => {
+                        let dc =
+                            textarea.abs_screen_to_data_cursor(me.row as usize, me.column as usize);
+                        if let Some(c) = dc {
+                            let char = textarea.lines()[c.0].chars().nth(c.1);
+                            mouse_pos = format!("Mouse: {:?} {:?}", dc, char);
+                        } else {
+                            mouse_pos = String::new();
+                        }
+                    }
+                    crossterm::event::MouseEventKind::Down(_button) => {
+                        // ignore
+                    }
+                    _ => {}
+                }
+            }
+            crossterm::event::Event::Key(ke) if ke.kind == KeyEventKind::Release => {
+                //    ignore
+                //draw = false;
+            }
+            ev => match ev.into() {
+                Input { key: Key::Esc, .. } => break,
+
+                Input {
+                    key: Key::Char('R'),
+                    ctrl: true,
+                    shift: true,
+                    alt: false,
+                } => textarea.set_wrap_mode(WrapMode::Word),
+                Input {
+                    key: Key::Char('Z'),
+                    ctrl: true,
+                    shift: true,
+                    alt: false,
+                } => textarea.set_wrap_mode(WrapMode::None),
+                Input {
+                    key: Key::Char('F'),
+                    ctrl: true,
+                    shift: true,
+                    alt: false,
+                } => textarea.set_wrap_mode(WrapMode::Char),
+
+                input => {
+                    if input.key != Key::Null {
+                        textarea.input(input.clone());
+                    };
+                }
+            },
+        }
+    }
+
+    disable_raw_mode()?;
+    crossterm::execute!(
+        term.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    term.show_cursor()?;
+
+    println!("Lines: {:?}", textarea.lines());
+    Ok(())
+}

--- a/examples/wrap_dem.rs
+++ b/examples/wrap_dem.rs
@@ -83,7 +83,7 @@ fn main() -> io::Result<()> {
                 Input { key: Key::Esc, .. } => break,
 
                 Input {
-                    key: Key::Char('R'),
+                    key: Key::Char('R' | 'r'),
                     ctrl: true,
                     shift: true,
                     alt: false,

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -10,10 +10,12 @@ use std::iter;
 use tui::text::Spans as Line;
 use unicode_width::UnicodeWidthChar as _;
 
+#[derive(Debug)]
 enum Boundary {
     Cursor(Style),
     #[cfg(feature = "search")]
     Search(Style),
+    Select(Style),
     End,
 }
 
@@ -21,9 +23,10 @@ impl Boundary {
     fn cmp(&self, other: &Boundary) -> Ordering {
         fn rank(b: &Boundary) -> u8 {
             match b {
-                Boundary::Cursor(_) => 2,
+                Boundary::Cursor(_) => 3,
                 #[cfg(feature = "search")]
                 Boundary::Search(_) => 1,
+                Boundary::Select(_) => 2,
                 Boundary::End => 0,
             }
         }
@@ -36,43 +39,59 @@ impl Boundary {
             #[cfg(feature = "search")]
             Boundary::Search(s) => Some(*s),
             Boundary::End => None,
+            Boundary::Select(s) => Some(*s),
         }
     }
 }
 
-fn line_display_text(s: &str, tab_len: u8, mask: Option<char>) -> Cow<'_, str> {
-    if let Some(ch) = mask {
-        // No tab character processing in the mask case
-        let masked = iter::repeat(ch).take(s.chars().count()).collect();
-        return Cow::Owned(masked);
-    }
+struct DisplayTextBuilder {
+    tab_len: u8,
+    width: usize,
+    mask: Option<char>,
+}
 
-    let tab = spaces(tab_len);
-    let mut buf = String::new();
-    let mut width = 0;
-    for (i, c) in s.char_indices() {
-        if c == '\t' {
-            if buf.is_empty() {
-                buf.reserve(s.len());
-                buf.push_str(&s[..i]);
-            }
-            if tab_len > 0 {
-                let len = tab_len as usize - (width % tab_len as usize);
-                buf.push_str(&tab[..len]);
-                width += len;
-            }
-        } else {
-            if !buf.is_empty() {
-                buf.push(c);
-            }
-            width += c.width().unwrap_or(0);
+impl DisplayTextBuilder {
+    fn new(tab_len: u8, mask: Option<char>) -> Self {
+        Self {
+            tab_len,
+            width: 0,
+            mask,
         }
     }
 
-    if !buf.is_empty() {
-        Cow::Owned(buf)
-    } else {
-        Cow::Borrowed(s)
+    fn build<'s>(&mut self, s: &'s str) -> Cow<'s, str> {
+        if let Some(ch) = self.mask {
+            // Note: We don't need to track width on masking text since width of tab character is fixed
+            let masked = iter::repeat(ch).take(s.chars().count()).collect();
+            return Cow::Owned(masked);
+        }
+
+        let tab = spaces(self.tab_len);
+        let mut buf = String::new();
+        for (i, c) in s.char_indices() {
+            if c == '\t' {
+                if buf.is_empty() {
+                    buf.reserve(s.len());
+                    buf.push_str(&s[..i]);
+                }
+                if self.tab_len > 0 {
+                    let len = self.tab_len as usize - (self.width % self.tab_len as usize);
+                    buf.push_str(&tab[..len]);
+                    self.width += len;
+                }
+            } else {
+                if !buf.is_empty() {
+                    buf.push(c);
+                }
+                self.width += c.width().unwrap_or(0);
+            }
+        }
+
+        if !buf.is_empty() {
+            Cow::Owned(buf)
+        } else {
+            Cow::Borrowed(s)
+        }
     }
 }
 
@@ -85,10 +104,17 @@ pub struct LineHighlighter<'a> {
     cursor_style: Style,
     tab_len: u8,
     mask: Option<char>,
+    select_style: Style,
 }
 
 impl<'a> LineHighlighter<'a> {
-    pub fn new(line: &'a str, cursor_style: Style, tab_len: u8, mask: Option<char>) -> Self {
+    pub fn new(
+        line: &'a str,
+        cursor_style: Style,
+        tab_len: u8,
+        mask: Option<char>,
+        select_style: Style,
+    ) -> Self {
         Self {
             line,
             spans: vec![],
@@ -98,6 +124,7 @@ impl<'a> LineHighlighter<'a> {
             cursor_style,
             tab_len,
             mask,
+            select_style,
         }
     }
 
@@ -105,6 +132,11 @@ impl<'a> LineHighlighter<'a> {
         let pad = spaces(lnum_len - num_digits(row + 1) + 1);
         self.spans
             .push(Span::styled(format!("{}{} ", pad, row + 1), style));
+    }
+
+    pub fn select(&mut self, start: usize, end: usize, style: Style) {
+        self.boundaries.push((Boundary::Select(style), start));
+        self.boundaries.push((Boundary::End, end));
     }
 
     pub fn cursor_line(&mut self, cursor_col: usize, style: Style) {
@@ -138,13 +170,12 @@ impl<'a> LineHighlighter<'a> {
             cursor_style,
             cursor_at_end,
             mask,
+            select_style,
         } = self;
+        let mut builder = DisplayTextBuilder::new(tab_len, mask);
 
         if boundaries.is_empty() {
-            spans.push(Span::styled(
-                line_display_text(line, tab_len, mask),
-                style_begin,
-            ));
+            spans.push(Span::styled(builder.build(line), style_begin));
             if cursor_at_end {
                 spans.push(Span::styled(" ", cursor_style));
             }
@@ -156,92 +187,140 @@ impl<'a> LineHighlighter<'a> {
             o => o,
         });
 
-        let mut boundaries = boundaries.into_iter();
+        // let mut boundaries = boundaries.into_iter();
         let mut style = style_begin;
         let mut start = 0;
         let mut stack = vec![];
-
-        loop {
-            if let Some((next_boundary, end)) = boundaries.next() {
-                if start < end {
-                    spans.push(Span::styled(
-                        line_display_text(&line[start..end], tab_len, mask),
-                        style,
-                    ));
-                }
-
-                style = if let Some(s) = next_boundary.style() {
-                    stack.push(style);
-                    s
+        let mut dont_add_cursor = false;
+        //  trace!("hl boundaries: {:?}", boundaries);
+        for (next_boundary, end) in boundaries {
+            //      trace!("hlb: {:?} {:?}", next_boundary, end);
+            //        trace!("xx {:?} {:?} {} {}", style, select_style, start, end);
+            if start < end {
+                // add extra select space at line end to indicate
+                // that the \n will be deleted / included
+                if end > line.chars().count() && style == select_style {
+                    spans.push(Span::styled(builder.build(&line[start..end - 1]), style));
+                    spans.push(Span::styled(" ", style));
+                    dont_add_cursor = true;
                 } else {
-                    stack.pop().unwrap_or(style_begin)
-                };
-                start = end;
-            } else {
-                if start != line.len() {
-                    spans.push(Span::styled(
-                        line_display_text(&line[start..], tab_len, mask),
-                        style,
-                    ));
+                    spans.push(Span::styled(builder.build(&line[start..end]), style));
                 }
-                if cursor_at_end {
-                    spans.push(Span::styled(" ", cursor_style));
-                }
-                return Line::from(spans);
             }
+
+            style = if let Some(s) = next_boundary.style() {
+                stack.push(style);
+                s
+            } else {
+                stack.pop().unwrap_or(style_begin)
+            };
+            start = end;
         }
+        if start < line.len() {
+            spans.push(Span::styled(builder.build(&line[start..]), style));
+        }
+        if cursor_at_end && !dont_add_cursor {
+            spans.push(Span::styled(" ", cursor_style));
+        }
+
+        Line::from(spans)
     }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unicode_width::UnicodeWidthStr as _;
+
+    fn build(text: &'static str, tab: u8, mask: Option<char>) -> Cow<'static, str> {
+        DisplayTextBuilder::new(tab, mask).build(text)
+    }
+
+    #[track_caller]
+    fn build_with_offset(offset: usize, text: &'static str, tab: u8) -> Cow<'static, str> {
+        let mut b = DisplayTextBuilder::new(tab, None);
+        b.width = offset;
+        let built = b.build(text);
+        let want = offset + built.as_ref().width();
+        assert_eq!(b.width, want, "in={:?}, out={:?}", text, built); // Check post condition
+        built
+    }
 
     #[test]
     #[rustfmt::skip]
     fn test_line_display_text() {
-        assert_eq!(&line_display_text(      "", 0,      None),                  "");
-        assert_eq!(&line_display_text(      "", 4,      None),                  "");
-        assert_eq!(&line_display_text(      "", 8,      None),                  "");
-        assert_eq!(&line_display_text(      "", 0, Some('x')),                  "");
-        assert_eq!(&line_display_text(      "", 4, Some('x')),                  "");
-        assert_eq!(&line_display_text(      "", 8, Some('x')),                  "");
-        assert_eq!(&line_display_text(     "a", 0,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 4,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 8,      None),                 "a");
-        assert_eq!(&line_display_text(     "a", 0, Some('x')),                 "x");
-        assert_eq!(&line_display_text(     "a", 4, Some('x')),                 "x");
-        assert_eq!(&line_display_text(     "a", 8, Some('x')),                 "x");
-        assert_eq!(&line_display_text(   "a\t", 0,      None),                 "a");
-        assert_eq!(&line_display_text(   "a\t", 4,      None),              "a   ");
-        assert_eq!(&line_display_text(   "a\t", 8,      None),          "a       ");
-        assert_eq!(&line_display_text(   "a\t", 0, Some('x')),                "xx");
-        assert_eq!(&line_display_text(   "a\t", 4, Some('x')),                "xx");
-        assert_eq!(&line_display_text(   "a\t", 8, Some('x')),                "xx");
-        assert_eq!(&line_display_text(    "\t", 0,      None),                "\t");
-        assert_eq!(&line_display_text(    "\t", 4,      None),              "    ");
-        assert_eq!(&line_display_text(    "\t", 8,      None),          "        ");
-        assert_eq!(&line_display_text(    "\t", 0, Some('x')),                 "x");
-        assert_eq!(&line_display_text(    "\t", 4, Some('x')),                 "x");
-        assert_eq!(&line_display_text(    "\t", 8, Some('x')),                 "x");
-        assert_eq!(&line_display_text(  "a\tb", 0,      None),                "ab");
-        assert_eq!(&line_display_text(  "a\tb", 4,      None),             "a   b");
-        assert_eq!(&line_display_text(  "a\tb", 8,      None),         "a       b");
-        assert_eq!(&line_display_text(  "a\tb", 0, Some('x')),               "xxx");
-        assert_eq!(&line_display_text(  "a\tb", 4, Some('x')),               "xxx");
-        assert_eq!(&line_display_text(  "a\tb", 8, Some('x')),               "xxx");
-        assert_eq!(&line_display_text("a\t\tb", 0,      None),                "ab");
-        assert_eq!(&line_display_text("a\t\tb", 4,      None),         "a       b");
-        assert_eq!(&line_display_text("a\t\tb", 8,      None), "a               b");
-        assert_eq!(&line_display_text("a\t\tb", 0, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("a\t\tb", 4, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("a\t\tb", 8, Some('x')),              "xxxx");
-        assert_eq!(&line_display_text("ab\t\t", 0,      None),                "ab");
-        assert_eq!(&line_display_text("ab\t\t", 4,      None),          "ab      ");
-        assert_eq!(&line_display_text("ab\t\t", 8,      None),  "ab              ");
-        assert_eq!(&line_display_text("abcd\t", 4,      None),          "abcd    ");
-        assert_eq!(&line_display_text(  "あ\t", 0,      None),                "あ");
-        assert_eq!(&line_display_text(  "あ\t", 4,      None),              "あ  ");
-        assert_eq!(&line_display_text(  "🐶\t", 4,      None),              "🐶  ");
-        assert_eq!(&line_display_text(  "あ\t", 4, Some('x')),                "xx");
+        assert_eq!(&build(      "",  0,      None),                  "");
+        assert_eq!(&build(      "",  4,      None),                  "");
+        assert_eq!(&build(      "",  8,      None),                  "");
+        assert_eq!(&build(      "",  0, Some('x')),                  "");
+        assert_eq!(&build(      "",  4, Some('x')),                  "");
+        assert_eq!(&build(      "",  8, Some('x')),                  "");
+        assert_eq!(&build(     "a",  0,      None),                 "a");
+        assert_eq!(&build(     "a",  4,      None),                 "a");
+        assert_eq!(&build(     "a",  8,      None),                 "a");
+        assert_eq!(&build(     "a",  0, Some('x')),                 "x");
+        assert_eq!(&build(     "a",  4, Some('x')),                 "x");
+        assert_eq!(&build(     "a",  8, Some('x')),                 "x");
+        assert_eq!(&build(   "a\t",  0,      None),                 "a");
+        assert_eq!(&build(   "a\t",  4,      None),              "a   ");
+        assert_eq!(&build(   "a\t",  8,      None),          "a       ");
+        assert_eq!(&build(   "a\t",  0, Some('x')),                "xx");
+        assert_eq!(&build(   "a\t",  4, Some('x')),                "xx");
+        assert_eq!(&build(   "a\t",  8, Some('x')),                "xx");
+        assert_eq!(&build(    "\t",  0,      None),                "\t");
+        assert_eq!(&build(    "\t",  4,      None),              "    ");
+        assert_eq!(&build(    "\t",  8,      None),          "        ");
+        assert_eq!(&build(    "\t",  0, Some('x')),                 "x");
+        assert_eq!(&build(    "\t",  4, Some('x')),                 "x");
+        assert_eq!(&build(    "\t",  8, Some('x')),                 "x");
+        assert_eq!(&build(  "a\tb",  0,      None),                "ab");
+        assert_eq!(&build(  "a\tb",  4,      None),             "a   b");
+        assert_eq!(&build(  "a\tb",  8,      None),         "a       b");
+        assert_eq!(&build(  "a\tb",  0, Some('x')),               "xxx");
+        assert_eq!(&build(  "a\tb",  4, Some('x')),               "xxx");
+        assert_eq!(&build(  "a\tb",  8, Some('x')),               "xxx");
+        assert_eq!(&build("a\t\tb",  0,      None),                "ab");
+        assert_eq!(&build("a\t\tb",  4,      None),         "a       b");
+        assert_eq!(&build("a\t\tb",  8,      None), "a               b");
+        assert_eq!(&build("a\t\tb",  0, Some('x')),              "xxxx");
+        assert_eq!(&build("a\t\tb",  4, Some('x')),              "xxxx");
+        assert_eq!(&build("a\t\tb",  8, Some('x')),              "xxxx");
+        assert_eq!(&build("a\tb\tc", 0,      None),               "abc");
+        assert_eq!(&build("a\tb\tc", 4,      None),         "a   b   c");
+        assert_eq!(&build("a\tb\tc", 8,      None), "a       b       c");
+        assert_eq!(&build("a\tb\tc", 0, Some('x')),             "xxxxx");
+        assert_eq!(&build("a\tb\tc", 4, Some('x')),             "xxxxx");
+        assert_eq!(&build("a\tb\tc", 8, Some('x')),             "xxxxx");
+        assert_eq!(&build("ab\t\t",  0,      None),                "ab");
+        assert_eq!(&build("ab\t\t",  4,      None),          "ab      ");
+        assert_eq!(&build("ab\t\t",  8,      None),  "ab              ");
+        assert_eq!(&build("abcd\t",  4,      None),          "abcd    ");
+        assert_eq!(&build(  "あ\t",  0,      None),                "あ");
+        assert_eq!(&build(  "あ\t",  4,      None),              "あ  ");
+        assert_eq!(&build(  "🐶\t",  4,      None),              "🐶  ");
+        assert_eq!(&build(  "あ\t",  4, Some('x')),                "xx");
+
+        // When the start position of the text is not start of the line (#43)
+        assert_eq!(&build_with_offset(1,         "", 0),           "");
+        assert_eq!(&build_with_offset(1,        "a", 0),          "a");
+        assert_eq!(&build_with_offset(1,       "あ", 0),         "あ");
+        assert_eq!(&build_with_offset(1,       "\t", 4),        "   ");
+        assert_eq!(&build_with_offset(1,      "a\t", 4),        "a  ");
+        assert_eq!(&build_with_offset(1,     "あ\t", 4),        "あ ");
+        assert_eq!(&build_with_offset(2,       "\t", 4),         "  ");
+        assert_eq!(&build_with_offset(2,      "a\t", 4),         "a ");
+        assert_eq!(&build_with_offset(2,     "あ\t", 4),     "あ    ");
+        assert_eq!(&build_with_offset(3,      "a\t", 4),      "a    ");
+        assert_eq!(&build_with_offset(4,       "\t", 4),       "    ");
+        assert_eq!(&build_with_offset(4,      "a\t", 4),       "a   ");
+        assert_eq!(&build_with_offset(4,     "あ\t", 4),       "あ  ");
+        assert_eq!(&build_with_offset(5,       "\t", 4),        "   ");
+        assert_eq!(&build_with_offset(5,      "a\t", 4),        "a  ");
+        assert_eq!(&build_with_offset(5,     "あ\t", 4),        "あ ");
+        assert_eq!(&build_with_offset(2,     "\t\t", 4),     "      ");
+        assert_eq!(&build_with_offset(2,   "a\ta\t", 4),     "a a   ");
+        assert_eq!(&build_with_offset(1, "あ\tあ\t", 4),    "あ あ  ");
+        assert_eq!(&build_with_offset(2, "あ\tあ\t", 4), "あ    あ  ");
     }
+
+    // TODO: Add tests for LineHighlighter
 }

--- a/src/input/crossterm.rs
+++ b/src/input/crossterm.rs
@@ -49,9 +49,15 @@ impl From<KeyEvent> for Input {
 
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
         let key = Key::from(key.code);
 
-        Self { key, ctrl, alt }
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -72,7 +78,14 @@ impl From<MouseEvent> for Input {
         let key = Key::from(mouse.kind);
         let ctrl = mouse.modifiers.contains(KeyModifiers::CONTROL);
         let alt = mouse.modifiers.contains(KeyModifiers::ALT);
-        Self { key, ctrl, alt }
+        let shift = mouse.modifiers.contains(KeyModifiers::SHIFT);
+
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -90,7 +90,7 @@ impl Default for Key {
 /// textarea.input(Input {
 ///     key: Key::Char('a'),
 ///     ctrl: true,
-///     alt: false,
+///     alt: false,shift:false
 /// });
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Hash)]
@@ -102,6 +102,8 @@ pub struct Input {
     pub ctrl: bool,
     /// Alt modifier key. `true` means Alt key was pressed.
     pub alt: bool,
+    // Shift key.  `true` means Shift key was pressed.
+    pub shift: bool,
 }
 
 #[cfg(test)]
@@ -110,7 +112,12 @@ mod tests {
 
     #[allow(dead_code)]
     pub(crate) fn input(key: Key, ctrl: bool, alt: bool) -> Input {
-        Input { key, ctrl, alt }
+        Input {
+            key,
+            ctrl,
+            alt,
+            shift: false,
+        }
     }
 
     #[test]

--- a/src/input/termion.rs
+++ b/src/input/termion.rs
@@ -17,6 +17,7 @@ impl From<KeyEvent> for Input {
     fn from(key: KeyEvent) -> Self {
         let mut ctrl = false;
         let mut alt = false;
+        let shift = false;
         let key = match key {
             KeyEvent::Char('\n' | '\r') => Key::Enter,
             KeyEvent::Char(c) => Key::Char(c),
@@ -44,7 +45,12 @@ impl From<KeyEvent> for Input {
             _ => Key::Null,
         };
 
-        Input { key, ctrl, alt }
+        Input {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -71,6 +77,7 @@ impl From<MouseEvent> for Input {
             key,
             ctrl: false,
             alt: false,
+            shift: false,
         }
     }
 }

--- a/src/input/termwiz.rs
+++ b/src/input/termwiz.rs
@@ -46,8 +46,13 @@ impl From<KeyEvent> for Input {
         let key = Key::from(key);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -77,8 +82,13 @@ impl From<MouseEvent> for Input {
         let key = Key::from(mouse_buttons);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 
@@ -94,8 +104,13 @@ impl From<PixelMouseEvent> for Input {
         let key = Key::from(mouse_buttons);
         let ctrl = modifiers.contains(Modifiers::CTRL);
         let alt = modifiers.contains(Modifiers::ALT);
-
-        Self { key, ctrl, alt }
+        let shift = modifiers.contains(Modifiers::SHIFT);
+        Self {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,34 @@
 #[cfg(all(feature = "ratatui", feature = "tuirs"))]
 compile_error!("ratatui support and tui-rs support are exclusive. only one of them can be enabled at the same time. see https://github.com/rhysd/tui-textarea#installation");
 
+#[macro_export]
+macro_rules! trace {
+    ($fmt:literal, $($arg:expr),*) => {
+        #[cfg(debug_assertions)]
+        {
+            if cfg!(test){
+                println!($fmt, $($arg),*);
+            } else {
+                log::warn!($fmt, $($arg),*);
+            }
+        }
+    };
+    ($msg:expr) => {
+        #[cfg(debug_assertions)]
+        {
+            if cfg!(test){
+                println!($msg);
+            } else {
+                log::warn!($msg);
+            }
+        }
+    };
+}
 mod cursor;
 mod highlight;
 mod history;
 mod input;
+mod screen_map;
 mod scroll;
 #[cfg(feature = "search")]
 mod search;
@@ -35,3 +59,4 @@ pub use cursor::CursorMove;
 pub use input::{Input, Key};
 pub use scroll::Scrolling;
 pub use textarea::TextArea;
+pub use textarea::WrapMode;

--- a/src/screen_map.rs
+++ b/src/screen_map.rs
@@ -1,0 +1,576 @@
+use unicode_width::UnicodeWidthChar;
+
+use crate::{
+    cursor::{DataCursor, ScreenCursor},
+    history::EditKind,
+    word::find_word_start_backward,
+    TextArea, WrapMode,
+};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LinePtr {
+    pub data_line: usize,    // parent data line index
+    pub byte_offset: usize,  // start of slice line in data line
+    pub byte_length: usize,  // length of slice in data line
+    pub data_offset: usize,  // offset of slice in parent data line
+    pub screen_width: usize, // space occupied on screen by this line
+    pub lp_num: usize,       // this is the nth lp for a given data line
+    pub lp_count: usize,     // this is the number of lps for a given data line
+    pub last: bool,          // this is the last lp for a given data line
+}
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DataLine {
+    first_screen_line: usize, // pointer to first LinePtr for this data line
+    pure_ascii: bool,         // line only has ascii and no hard tabs
+}
+
+// lifted from rust std source
+pub(crate) fn is_utf8_char_boundary(b: u8) -> bool {
+    (b as i8) >= -0x40
+}
+
+impl<'a> TextArea<'a> {
+    pub(crate) fn screen_line_width(&self, line: usize) -> usize {
+        // the spce occuupied by a screen line , in 1 byte chars
+        self.screen_lines.borrow()[line].screen_width
+    }
+    pub(crate) fn screen_lines_count(&self) -> usize {
+        self.screen_lines.borrow().len()
+    }
+    pub(crate) fn screen_cursor_in_bounds(&self, sc: ScreenCursor) -> bool {
+        let screen_lines = self.screen_lines.borrow();
+        trace!("screen_cursor_in_bounds {:?} ", sc);
+        if sc.row >= screen_lines.len() {
+            trace!("screen_cursor_in_bounds false row {}", screen_lines.len());
+            return false;
+        }
+        let lp = &screen_lines[sc.row];
+        if sc.col >= lp.screen_width {
+            trace!("screen_cursor_in_bounds false col {}", lp.screen_width);
+            return false;
+        }
+        trace!("screen_cursor_in_bounds true");
+        true
+    }
+    pub(crate) fn screen_to_array(&self, screen: ScreenCursor) -> DataCursor {
+        trace!("screen_to_array start {:?} ", screen);
+        if screen.dc.is_some() {
+            trace!("Fast out");
+            //     return screen.dc.unwrap();
+        }
+        let screen_lines = self.screen_lines.borrow();
+        let screen_line = &screen_lines[screen.row];
+        let data_pointer = &(*self.data_pointers.borrow())[screen_line.data_line];
+        let data_idx = screen_line.data_line;
+
+        // if we are in pure ascii mode then and not wrapping
+        // then sc === dc
+        let fasdc = if self.wrap_mode == WrapMode::None && data_pointer.pure_ascii {
+            trace!("Fastish out");
+            Some(DataCursor(data_idx, screen.col))
+        } else {
+            None
+        };
+        let screen_lines = self.screen_lines.borrow();
+        let screen_line = &screen_lines[screen.row];
+        let data_idx = screen_line.data_line;
+        let mut off = 0;
+
+        let last_lp_line = &screen_lines[screen.row];
+        trace!("last_lp_line {:?} ", last_lp_line);
+        let mut chidx = 0;
+        let slice = &self.lines[data_idx][last_lp_line.byte_offset..];
+
+        for (_i, c) in slice.char_indices() {
+            if off == screen.col {
+                break;
+            };
+
+            if off > screen.col {
+                // this happens if somebody asks about a char
+                // at r.c and its not on a char boundary
+                // so we back up one char
+                chidx -= 1;
+                break;
+            }
+            chidx += 1;
+            off += UnicodeWidthChar::width(c).unwrap_or(0);
+        }
+        //assert_eq!(off, screen.col);
+        let off = last_lp_line.data_offset + chidx;
+        let ret = DataCursor(screen_line.data_line, off);
+        trace!("screen_to_array {:?} {:?}", screen, ret);
+        if fasdc.is_some() {
+            assert_eq!(fasdc.unwrap(), ret);
+        }
+        ret
+    }
+    pub(crate) fn array_to_screen(&self, array: DataCursor) -> ScreenCursor {
+        trace!("array_to_screen start {:?} ", array);
+        // if we are in pure ascii mode then and not wrapping
+        // then sc === dc
+        let pure = self.data_pointers.borrow()[array.0].pure_ascii;
+        let fastsc = if self.wrap_mode == WrapMode::None && pure {
+            trace!("Fastish out");
+            Some(ScreenCursor {
+                row: array.0,
+                col: array.1,
+                char: Some(self.lines[array.0].chars().nth(array.1).unwrap()),
+                dc: Some(array),
+            })
+        } else {
+            None
+        };
+        let first_screen_line_idx = self.data_pointers.borrow()[array.0].first_screen_line;
+        let screen_lines = self.screen_lines.borrow();
+        let data_line = &self.lines[array.0];
+        let mut found_idx = first_screen_line_idx;
+        for lp in &screen_lines[first_screen_line_idx..] {
+            if lp.data_line != array.0 || lp.data_offset > array.1 {
+                break;
+            }
+            found_idx += 1;
+        }
+        let found_lp = &screen_lines[found_idx - 1];
+        let mut width = 0;
+        // let mut idx = 0;
+        let mut ch = None;
+        trace!("found_lp {:?} {}", found_lp, data_line);
+        for (idx, (_i, c)) in data_line[found_lp.byte_offset..].char_indices().enumerate() {
+            if idx == array.1 - found_lp.data_offset {
+                ch = Some(c);
+                break;
+            }
+
+            width += UnicodeWidthChar::width(c).unwrap_or(0);
+        }
+
+        let ret = ScreenCursor {
+            row: found_idx - 1,
+            col: width,
+            char: ch,
+            dc: Some(array),
+        };
+        trace!("array_to_screen {:?} {:?}", array, ret);
+        if fastsc.is_some() {
+            assert_eq!(fastsc.unwrap(), ret);
+        }
+        ret
+    }
+
+    fn analyze_line(line: &str) -> (Vec<(usize, usize, char, usize)>, bool) {
+        let mut v = Vec::new();
+        let mut pure_ascii = false;
+        for (i, c) in line.char_indices() {
+            let utf8 = c.len_utf8();
+            let width = UnicodeWidthChar::width(c).unwrap_or(0);
+            if width > 1 || !utf8 != 1 || c == '\t' {
+                pure_ascii = false;
+            }
+            v.push((utf8, width, c, i));
+        }
+        (v, pure_ascii)
+    }
+    fn chop_line(&self, line: &str, width: usize, line_num: usize) -> (Vec<LinePtr>, bool) {
+        let width = if self.wrap_mode == WrapMode::None {
+            usize::MAX
+        } else {
+            width
+        };
+        let mut start = 0;
+        let mut lps = Vec::new();
+        let (al, pure) = Self::analyze_line(line);
+        //let data_lines = al.iter().map(|(u, _, _, _)| *u as u8).collect::<Vec<_>>();
+        let on_screen_len = al.iter().fold(0, |acc, (_, w, _, _)| acc + w);
+        trace!("chop_line {} {} {}", on_screen_len, width, pure);
+        let mut chidx = 0;
+        let mut scwidth = 0;
+        let mut dataoff = 0;
+
+        while chidx < al.len() {
+            let alc = &al[chidx];
+            dataoff = alc.3;
+            if scwidth + alc.1 > width {
+                // reached part of line that overflows screen width
+                if let Some(off) = find_word_start_backward(line, chidx) {
+                    trace!(
+                        "find back({:?}, chidx-> {:?} returns {} -> {:?}",
+                        al[start],
+                        al[chidx],
+                        off,
+                        al[off]
+                    );
+
+                    if off == 0 {
+                        // no word to back up to, just chop the line
+                        let lp = LinePtr {
+                            data_line: line_num,
+                            byte_offset: al[start].3,
+                            byte_length: al[chidx].3 - al[start].3,
+                            data_offset: start,
+                            screen_width: scwidth,
+                            last: false,
+                            lp_num: lps.len(),
+                            lp_count: 0,
+                        };
+                        debug_assert!(is_utf8_char_boundary(line.as_bytes()[al[start].3]));
+                        start = chidx;
+                        lps.push(lp);
+                    } else {
+                        // off returns start of prior word
+                        // back track screen width the start of word
+                        trace!("backtrack {:?} {} ", chidx, off);
+                        for i in off..chidx + 1 {
+                            trace!("backtrack {:?} {} ", al[i], scwidth);
+                            scwidth -= al[i].1;
+                        }
+                        trace!("st {:?} scan {:?} ", al[off], al[start]);
+                        let lp = LinePtr {
+                            data_line: line_num,
+                            byte_offset: al[start].3,
+                            byte_length: al[off].3 - al[start].3,
+                            data_offset: start,
+                            screen_width: scwidth,
+                            last: false,
+                            lp_num: lps.len(),
+                            lp_count: 0,
+                        };
+                        debug_assert!(is_utf8_char_boundary(line.as_bytes()[al[start].3]));
+                        debug_assert!(is_utf8_char_boundary(
+                            line.as_bytes()[al[start].3 + lp.byte_length]
+                        ));
+                        start = off;
+                        chidx = off;
+                        lps.push(lp);
+                    }
+                } else {
+                    break;
+                }
+                scwidth = 0;
+            } else {
+                chidx += 1;
+                scwidth += alc.1;
+            }
+        }
+        let lp = if chidx == 0 {
+            // the whole line fits on the screen
+            LinePtr {
+                data_line: line_num,
+                byte_offset: 0,
+                byte_length: 0,
+                data_offset: 0,
+                screen_width: scwidth,
+                last: true,
+                lp_num: lps.len(),
+                lp_count: 0,
+            }
+        } else {
+            // the last peice of the line
+            assert!(is_utf8_char_boundary(line.as_bytes()[al[start].3]));
+            LinePtr {
+                data_line: line_num,
+                byte_offset: al[start].3,
+                byte_length: line.len() - al[start].3,
+                data_offset: start,
+                screen_width: scwidth,
+                last: true,
+                lp_num: lps.len(),
+                lp_count: 0,
+            }
+        };
+        lps.push(lp);
+        if scwidth == width {
+            // we exactly hit the width, need a new empty next screen line
+            // becuase the cursor moves to the next line
+            let lpc = lps.len() - 1;
+            lps[lpc].last = false;
+            let lp = LinePtr {
+                data_line: line_num,
+                byte_offset: lps[lpc].byte_length + lps[lpc].byte_offset,
+                byte_length: 0,
+                data_offset: dataoff + 1,
+                screen_width: 0,
+                last: true,
+                lp_num: lps.len(),
+                lp_count: 0,
+            };
+            lps.push(lp);
+        }
+        let lp_count = lps.len();
+        for i in 0..lps.len() {
+            let lp = &mut lps[i];
+            lp.lp_count = lp_count;
+        }
+
+        (lps, pure)
+    }
+
+    fn get_width(&self) -> usize {
+        self.area.get().width as usize
+    }
+
+    pub(crate) fn screen_map_load(&self) {
+        {
+            let mut screen_lines = self.screen_lines.borrow_mut();
+            screen_lines.clear();
+            let mut data_pointers = self.data_pointers.borrow_mut();
+            data_pointers.clear();
+            let width = self.get_width();
+            trace!("load {} {}", self.lines.len(), width);
+            for (line_num, line) in self.lines.iter().enumerate() {
+                let (cl, pure) = self.chop_line(line, width, line_num);
+                data_pointers.push(DataLine {
+                    first_screen_line: screen_lines.len(),
+                    pure_ascii: pure,
+                });
+                screen_lines.extend(cl);
+            }
+        }
+        self.dump();
+    }
+
+    // the follwing functions are perf optimizations
+    // rather than recalculating the screen table from scratch
+    // common operations update it incrementatlly
+
+    pub(crate) fn update_screen_map(&mut self, kind: &EditKind, cursor_before: DataCursor) {
+        match kind {
+            EditKind::InsertChar(_, _) => self.update_line(cursor_before.0),
+
+            EditKind::DeleteChar(_, _) => self.update_line(cursor_before.0),
+
+            EditKind::InsertNewline(_) => self.insert_line(cursor_before.0),
+            EditKind::DeleteNewline(_) => self.delete_line(cursor_before.0),
+            _ => self.screen_map_load(),
+        }
+    }
+
+    fn update_line(&mut self, row: usize) {
+        // update table when a line is changed
+
+        let line = &self.lines[row];
+        let (cl, _pure) = self.chop_line(line, self.get_width(), row);
+        let line_start = self.data_pointers.get_mut()[row].first_screen_line;
+        let screen_lines = self.screen_lines.get_mut();
+
+        let curr_first_lp = &screen_lines[line_start];
+        let lp_count = curr_first_lp.lp_count;
+        let cl_count = cl.len();
+        screen_lines.splice(line_start..line_start + lp_count, cl);
+
+        let delta = lp_count as i32 - cl_count as i32;
+
+        for i in row + 1..self.data_pointers.get_mut().len() {
+            let dp = &mut self.data_pointers.get_mut()[i];
+            dp.first_screen_line = (dp.first_screen_line as i32 - delta) as usize;
+        }
+        //self.verify_update();
+    }
+    fn delete_line(&mut self, row: usize) {
+        //wip - update tablasdfe when line is deleted
+
+        trace!("delete_line {}", row);
+        assert!(row != 0);
+        let line_start = self.data_pointers.get_mut()[row].first_screen_line;
+        let screen_lines = self.screen_lines.get_mut();
+        self.data_pointers.get_mut().remove(row);
+        let curr_first_lp = &screen_lines[line_start];
+        assert!(curr_first_lp.lp_count == 1);
+        screen_lines.remove(line_start);
+        for i in line_start..screen_lines.len() {
+            let lp = &mut screen_lines[i];
+            lp.data_line -= 1;
+        }
+        for i in row..self.data_pointers.get_mut().len() {
+            let dp = &mut self.data_pointers.get_mut()[i];
+            dp.first_screen_line -= 1;
+        }
+        self.update_line(row - 1);
+        // self.verify_update();
+    }
+
+    fn insert_line(&mut self, row: usize) {
+        // wip - update table when line is inserted
+
+        trace!("insert_line {}", row);
+
+        let row = row + 1;
+        let line = &self.lines[row];
+        let (cl, pure) = self.chop_line(line, self.get_width(), row);
+        let screen_lines = self.screen_lines.get_mut();
+        let line_start = if row == 0 {
+            0
+        } else {
+            let x = self.data_pointers.get_mut()[row - 1].first_screen_line;
+            let curr_first_lp = &screen_lines[x];
+            x + curr_first_lp.lp_count
+        };
+        for i in line_start..screen_lines.len() {
+            let lp = &mut screen_lines[i];
+            lp.data_line += 1;
+        }
+        for i in row..self.data_pointers.get_mut().len() {
+            let dp = &mut self.data_pointers.get_mut()[i];
+            dp.first_screen_line += 1;
+        }
+        screen_lines.splice(line_start..line_start, cl);
+        self.data_pointers.get_mut().insert(
+            row,
+            DataLine {
+                first_screen_line: line_start,
+                pure_ascii: pure,
+            },
+        );
+        self.update_line(row - 1);
+        //  self.verify_update();
+    }
+
+    fn _verify_update(&mut self) {
+        self.dump();
+        let save_da = self.data_pointers.borrow().clone();
+        let save_lp = self.screen_lines.borrow().clone();
+        self.screen_map_load();
+        self.dump();
+        assert_eq!(save_da, *self.data_pointers.borrow());
+        assert_eq!(save_lp, *self.screen_lines.borrow());
+    }
+
+    pub(crate) fn data_cursor(&self, sc: ScreenCursor) -> DataCursor {
+        sc.to_array_cursor(self)
+    }
+    pub fn viewport(&self) -> (u16, u16, u16, u16) {
+        self.viewport.position()
+    }
+    pub(crate) fn increment_screen_cursor(&self, sc: ScreenCursor) -> ScreenCursor {
+        let dc = sc.to_array_cursor(self);
+        let char = self.lines[dc.0].chars().nth(dc.1).unwrap();
+        let width = UnicodeWidthChar::width(char).unwrap_or(0);
+        ScreenCursor {
+            col: sc.col + width,
+            ..sc
+        }
+    }
+    pub(crate) fn decrement_screen_cursor(&self, sc: ScreenCursor) -> ScreenCursor {
+        let dc = sc.to_array_cursor(self);
+        let char = self.lines[dc.0].chars().nth(dc.1 - 1).unwrap();
+        let width = UnicodeWidthChar::width(char).unwrap_or(0);
+        ScreenCursor {
+            col: sc.col - width,
+            ..sc
+        }
+    }
+    // pub(crate) fn char_at_screen_cursor(&self, sc: ScreenCursor) -> Option<char> {
+    //     let dc = sc.to_array_cursor(&self);
+    //     let char = self.lines[dc.0].chars().nth(dc.1);
+    //     char
+    // }
+    pub(crate) fn char_at_array_cursor(&self, dc: DataCursor) -> Option<char> {
+        let char = self.lines[dc.0].chars().nth(dc.1);
+        char
+    }
+    fn dump(&self) {
+        let screen_lines = self.screen_lines.borrow();
+        for lp in &(*screen_lines) {
+            trace!("{:?} ", lp);
+        }
+
+        for i in 0..self.lines.len() {
+            trace!(
+                "data pointer {} {:?} {}",
+                i,
+                self.data_pointers.borrow()[i],
+                self.lines[i]
+            );
+        }
+    }
+}
+#[cfg(test)]
+mod test {
+    use crate::ratatui::layout::Rect;
+
+    use super::*;
+    fn round_trip_a(dc: DataCursor, ta: &TextArea) {
+        trace!("round_trip_a {:?}", dc);
+        let sc = ta.array_to_screen(dc);
+        assert_eq!(ta.screen_to_array(sc), dc);
+    }
+    fn round_trip_s(sc: ScreenCursor, ta: &TextArea) {
+        trace!("round_trip_s {:?}", sc);
+        let dc = ta.screen_to_array(sc);
+        let retsc = ta.array_to_screen(dc);
+        assert_eq!(retsc.row, sc.row);
+        assert_eq!(retsc.col, sc.col);
+    }
+
+    fn smash_sm(lines: &Vec<String>) {
+        let tta = TextArea::from(lines);
+        tta.area.set(Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 100,
+        });
+        tta.screen_map_load();
+        let screen_lines = &*tta.screen_lines.borrow();
+
+        for lp in screen_lines {
+            trace!("{:?} ", lp);
+        }
+        for lp in screen_lines {
+            let slice =
+                lines[lp.data_line][lp.byte_offset..lp.byte_length + lp.byte_offset].to_string();
+            trace!("{:?} ", slice);
+        }
+
+        for dp in tta.data_pointers.borrow().iter() {
+            trace!("{:?} ", dp);
+        }
+        round_trip_a(DataCursor(0, 5), &tta);
+        for i in 0..lines.len() {
+            round_trip_a(DataCursor(i, 0), &tta);
+            //    round_trip_a(DataCursor(i, lines[i].chars().count() - 1), &tta);
+            //  round_trip_a(DataCursor(i, lines[i].chars().count() / 2), &tta);
+            for j in 0..lines[i].chars().count() {
+                round_trip_a(DataCursor(i, j), &tta);
+            }
+        }
+        for i in 0..screen_lines.len() {
+            round_trip_s(
+                ScreenCursor {
+                    row: i,
+                    col: 0,
+                    char: None,
+                    dc: None,
+                },
+                &tta,
+            );
+            //     round_trip_s(ScreenCursor(i, screen_lines[i].byte_length - 1), &tta);
+            //     round_trip_s(ScreenCursor(i, screen_lines[i].byte_length / 2), &tta);
+        }
+    }
+    #[test]
+    fn test_wrap_ascii() {
+        let lorem = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.  ",
+    "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+     " It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum"];
+        // let lines = vec!("Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore");
+        let lines = lorem.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+
+        smash_sm(&lines);
+    }
+    #[test]
+    fn test_wrap_chinese() {
+        let multi = ["棵動道吧鼻帶牙村陽風童時抄或和現至至游學：黃朱苗綠音急石消看造貝同鳥再免告二士，很這員冰；飛造孝給以士工香浪、朱的化故水固聽路鴨工根來流胡，怎科麻造菜忍吉？共行發經信是，書視松北吉不"];
+        let lines = multi.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+
+        smash_sm(&lines);
+    }
+    #[test]
+    fn test_russian() {
+        let multi = ["Лорем ипсум долор сит амет, усу алтера путант цу. Вел ут еяуидем оффициис сцрипторем. Вивендум номинати сигниферумяуе не вим, омниум мнесарчум ат вим, ад утинам рецтеяуе репудиандае еос. Нец еи цлита бландит, сеа постеа модератиус персеяуерис ет. Еам ин веро пауло епицури. Цум еа порро сингулис, молестиае яуаерендум нец ан. Ид меа аудиам ассентиор, еи вис тамяуам сцрипторем.",
+        "Воцибус нусяуам сеа ат. Темпор цонсецтетуер еам ат. Идяуе сцрибентур ех меа. Ин неморе лабитур сед."];
+        let lines = multi.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+
+        smash_sm(&lines);
+    }
+}

--- a/src/screen_map.rs
+++ b/src/screen_map.rs
@@ -191,6 +191,7 @@ impl<'a> TextArea<'a> {
             let alc = &al[chidx];
             dataoff = alc.3;
             if scwidth + alc.1 > width {
+                trace!("chop_line {} {} {}", scwidth, start, chidx);
                 // reached part of line that overflows screen width
                 if let Some(off) = find_word_start_backward(line, chidx) {
                     trace!(
@@ -201,7 +202,7 @@ impl<'a> TextArea<'a> {
                         al[off]
                     );
 
-                    if off == 0 {
+                    if off == 0 || off - start < 2 {
                         // no word to back up to, just chop the line
                         let lp = LinePtr {
                             data_line: line_num,
@@ -213,6 +214,7 @@ impl<'a> TextArea<'a> {
                             lp_num: lps.len(),
                             lp_count: 0,
                         };
+                        trace!("lp {:?} ", lp);
                         debug_assert!(is_utf8_char_boundary(line.as_bytes()[al[start].3]));
                         start = chidx;
                         lps.push(lp);
@@ -235,6 +237,7 @@ impl<'a> TextArea<'a> {
                             lp_num: lps.len(),
                             lp_count: 0,
                         };
+                        trace!("lp {:?} ", lp);
                         debug_assert!(is_utf8_char_boundary(line.as_bytes()[al[start].3]));
                         debug_assert!(is_utf8_char_boundary(
                             line.as_bytes()[al[start].3 + lp.byte_length]

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,7 @@
-use crate::ratatui::style::{Color, Style};
+use crate::{
+    cursor::DataCursor,
+    ratatui::style::{Color, Style},
+};
 use regex::Regex;
 
 #[derive(Clone, Debug)]
@@ -38,7 +41,7 @@ impl Search {
     pub fn forward(
         &mut self,
         lines: &[String],
-        cursor: (usize, usize),
+        cursor: DataCursor,
         match_cursor: bool,
     ) -> Option<(usize, usize)> {
         let pat = if let Some(pat) = &self.pat {
@@ -46,7 +49,7 @@ impl Search {
         } else {
             return None;
         };
-        let (row, col) = cursor;
+        let DataCursor(row, col) = cursor;
         let current_line = &lines[row];
 
         // Search current line after cursor
@@ -94,7 +97,7 @@ impl Search {
     pub fn back(
         &mut self,
         lines: &[String],
-        cursor: (usize, usize),
+        cursor: DataCursor,
         match_cursor: bool,
     ) -> Option<(usize, usize)> {
         let pat = if let Some(pat) = &self.pat {
@@ -102,7 +105,7 @@ impl Search {
         } else {
             return None;
         };
-        let (row, col) = cursor;
+        let DataCursor(row, col) = cursor;
         let current_line = &lines[row];
 
         // Search current line before cursor

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -862,7 +862,9 @@ impl<'a> TextArea<'a> {
             if yank {
                 self.yank = removed.clone().into();
             };
-            self.push_history(EditKind::DeleteStr(removed, first_start), self.cursor);
+            if delete {
+                self.push_history(EditKind::DeleteStr(removed, first_start), self.cursor);
+            }
             return true;
         };
 
@@ -900,13 +902,14 @@ impl<'a> TextArea<'a> {
         if yank {
             self.yank = YankText::Chunk(deleted.clone());
         };
-
-        let edit = if deleted.len() == 1 {
-            EditKind::DeleteStr(deleted.remove(0), first_start)
-        } else {
-            EditKind::DeleteChunk(deleted, row, first_start)
-        };
-        self.push_history(edit, self.cursor);
+        if delete {
+            let edit = if deleted.len() == 1 {
+                EditKind::DeleteStr(deleted.remove(0), first_start)
+            } else {
+                EditKind::DeleteChunk(deleted, row, first_start)
+            };
+            self.push_history(edit, self.cursor);
+        }
 
         true
     }

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -886,7 +886,12 @@ impl<'a> TextArea<'a> {
             vec![self.lines[row][first_start..].to_string()]
         };
 
-        deleted.extend(self.lines.drain(row + 1..r));
+        if delete {
+            deleted.extend(self.lines.drain(row + 1..r));
+        } else {
+            deleted.extend(self.lines[row + 1..r].iter().map(|s| s.to_string()));
+        }
+
         if row + 1 < self.lines.len() {
             let mut last_line = if delete {
                 let ll = self.lines.remove(row + 1);

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -814,9 +814,8 @@ impl<'a> TextArea<'a> {
     }
 
     // grabs the specified (maybe multi line string)
-    // always placed in history
     // sometimes yanked
-    // sometimes deleted from lines array
+    // sometimes deleted from lines array and placed in history
 
     fn delete_str_internal(&mut self, chars: usize, yank: bool, delete: bool) -> bool {
         if chars == 0 {


### PR DESCRIPTION
@ryhsd I do not expect you to accept the PR. But I ask you to try it out, there is a new sample that shows it in action called wrap_dem. Just clone my repo , checkout branch wrap and run the sample wrap_dem. It starts in non wrap mode, you can toggle wrap on with ctrl-shift-r (wRap) or F1 and off with ctrl-shift-Z (Zero wrap) or F2

It required that tta knows at all times the relationship between the screen cursor and the data cursor, even in non-wordwrap they diverge - (non ascii chars etc), in wrap mode they are wildly different. Doing that enables a few other things. Importantly it sets the foundation for mouse support. Because mouse support requires that the mouse coordinates can be translated into data coordinates. This is simple with this change. The demo shows this, if you move the mouse over a character it tells you what that character is.

Note that this works with ascii, japanese, chinese, cyrillic, russion... I have tried with large bodies of text all mixed simultaneously. This web site will generate lorem text for you in any language https://www.lipsum.com/ - its what I used.  All tests pass, tried on windows, linux and mac.

You are going to hate the code because its a largish change, but please try it out before dismissing it as a minor feature. Knowing precisely where any piece of text is on the screen is very useful for the caller (Imagine they want to do a spell check, or you want to add mouse driven text selection... these all become simple)

The merge is tricky and I dont want to go through it all if you are going to say no because its just too big. If you want I can add a readme / comment block that explains how it works.
