### PR TITLE
Bump Ratatui to 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,7 @@ repository = "https://github.com/rhysd/tui-textarea"
 readme = "README.md"
 categories = ["text-editors", "text-processing"]
 keywords = ["tui", "textarea", "editor", "input", "ratatui"]
-include = [
-    "/src",
-    "/examples",
-    "/tests",
-    "/README.md",
-    "/LICENSE.txt",
-]
+include = ["/src", "/examples", "/tests", "/README.md", "/LICENSE.txt"]
 
 [features]
 default = ["crossterm"]
@@ -42,10 +36,10 @@ search = ["dep:regex"]
 arbitrary = { version = "1", features = ["derive"], optional = true }
 crossterm = { package = "crossterm", version = "0.27", optional = true }
 crossterm-025 = { package = "crossterm", version = "0.25", optional = true }
-ratatui = { version = ">=0.23.0, <1", default-features = false, optional = true }
+ratatui = { version = "0.27", default-features = false, optional = true }
 regex = { version = "1", optional = true }
-termion = { version = "2.0", optional = true }
-termwiz = { version = "0.20.0", optional = true }
+termion = { version = "4.0", optional = true }
+termwiz = { version = "0.22.0", optional = true }
 tui = { version = "0.19", default-features = false, optional = true }
 unicode-width = "0.1.11"
 
@@ -102,9 +96,7 @@ name = "tuirs_termion"
 required-features = ["tuirs-termion"]
 
 [workspace]
-members = [
-    "bench",
-]
+members = ["bench"]
 
 [profile.bench]
 lto = "thin"


### PR DESCRIPTION
- Updates termion and termwiz
- Fixes issue where tui-textarea picks up the wrong versions of packages
  https://github.com/rhysd/tui-textarea/pull/61\#discussion_r1597672569
- Replaces #61
