### PR TITLE
add an option to show cursor and placeholder together

### DIFF
--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -94,6 +94,7 @@ pub struct TextArea<'a> {
     alignment: Alignment,
     pub(crate) placeholder: String,
     pub(crate) placeholder_style: Style,
+    pub(crate) show_placeholder_with_cursor: bool, // not supported for tui-rs
     mask: Option<char>,
     selection_start: Option<(usize, usize)>,
     select_style: Style,
@@ -199,6 +200,7 @@ impl<'a> TextArea<'a> {
             alignment: Alignment::Left,
             placeholder: String::new(),
             placeholder_style: Style::default().fg(Color::DarkGray),
+            show_placeholder_with_cursor: false,
             mask: None,
             selection_start: None,
             select_style: Style::default().bg(Color::LightBlue),
@@ -1850,6 +1852,20 @@ impl<'a> TextArea<'a> {
     /// ```
     pub fn set_placeholder_style(&mut self, style: Style) {
         self.placeholder_style = style;
+    }
+
+    /// Set if cursor and placeholder are shown together. The default value is `false`.
+    /// ```
+    /// use tui_textarea::TextArea;
+    ///
+    /// let mut textarea = TextArea::default();
+    /// assert_eq!(textarea.show_placeholder_with_cursor, false);
+    ///
+    /// textarea.set_show_placeholder_with_cursor(true);
+    /// assert_eq!(textarea.show_placeholder_with_cursor, true);
+    /// ```
+    pub fn set_show_placeholder_with_cursor(&mut self, enabled: bool) {
+        self.show_placeholder_with_cursor = enabled;
     }
 
     /// Get the placeholder text. An empty string means the placeholder is disabled. The default value is an empty string.

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -120,7 +120,25 @@ impl<'a> Widget for Renderer<'a> {
         let top_col = next_scroll_top(top_col, cursor.1 as u16, width);
 
         let (text, style) = if !self.0.placeholder.is_empty() && self.0.is_empty() {
+            #[cfg(any(
+                feature = "tuirs-crossterm",
+                feature = "tuirs-termion",
+                feature = "tuirs-no-backend",
+            ))]
             let text = Text::from(self.0.placeholder.as_str());
+
+            #[cfg(not(any(
+                feature = "tuirs-crossterm",
+                feature = "tuirs-termion",
+                feature = "tuirs-no-backend",
+            )))]
+            let text = if self.0.show_placeholder_with_cursor {
+                let mut text = self.text(top_row as usize, height as usize);
+                text.push_span(self.0.placeholder.as_str());
+                text
+            } else {
+                Text::from(self.0.placeholder.as_str())
+            };
             (text, self.0.placeholder_style)
         } else {
             (self.text(top_row as usize, height as usize), self.0.style())


### PR DESCRIPTION
## What
I added an option to show cursor with placeholder. This is disabled by default.
<img width="453" alt="image" src="https://github.com/user-attachments/assets/5cb4d228-4133-4d7e-b6cb-01510a0098d8">

## Motivation
I feel it is more common that cursor and placeholder are shown together. Also users can understand easily they can input.