### PR TITLE
add `CursorMove` for next end of word

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Values of the following types can be serialized/deserialized:
 
 Here is an example for deserializing key input from JSON using [serde_json][].
 
-```rust
+```rust,ignore
 use tui_textarea::Input;
 
 let json = r#"

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ notify how to move the cursor.
 | `textarea.move_cursor(CursorMove::Up)`               | Move cursor up by one line                      |
 | `textarea.move_cursor(CursorMove::Down)`             | Move cursor down by one line                    |
 | `textarea.move_cursor(CursorMove::WordForward)`      | Move cursor forward by word                     |
+| `textarea.move_cursor(CursorMove::WordEnd)`          | Move cursor to next end of word                 |
 | `textarea.move_cursor(CursorMove::WordBack)`         | Move cursor backward by word                    |
 | `textarea.move_cursor(CursorMove::ParagraphForward)` | Move cursor up by paragraph                     |
 | `textarea.move_cursor(CursorMove::ParagraphBack)`    | Move cursor down by paragraph                   |

--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -113,6 +113,11 @@ impl Vim {
                         ..
                     } => textarea.move_cursor(CursorMove::WordForward),
                     Input {
+                        key: Key::Char('e'),
+                        ctrl: false,
+                        ..
+                    } => textarea.move_cursor(CursorMove::WordEnd),
+                    Input {
                         key: Key::Char('b'),
                         ctrl: false,
                         ..

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -289,14 +289,15 @@ impl CursorMove {
             WordEnd => {
                 if let Some(col) = find_word_end_next(&lines[row], col) {
                     Some((row, col))
+                } else if let Some(col) = (row + 1 < lines.len())
+                    .then(|| find_word_end_next(&lines[row + 1], 0))
+                    .unwrap_or_default()
+                {
+                    Some((row + 1, col))
                 } else if row + 1 < lines.len() {
-                    if let Some(col) = find_word_end_next(&lines[row + 1], 0) {
-                        Some((row + 1, col))
-                    } else {
-                        Some((row + 1, lines[row + 1].chars().count()))
-                    }
+                    Some((row + 1, lines[row + 1].chars().count().saturating_sub(1)))
                 } else {
-                    Some((row, lines[row].chars().count()))
+                    Some((row, lines[row].chars().count().saturating_sub(1)))
                 }
             }
             WordForward => {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,5 +1,5 @@
 use crate::widget::Viewport;
-use crate::word::{find_word_start_backward, find_word_start_forward};
+use crate::word::{find_word_end_next, find_word_start_backward, find_word_start_forward};
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[cfg(feature = "serde")]
@@ -121,6 +121,29 @@ pub enum CursorMove {
     /// assert_eq!(textarea.cursor(), (0, 8));
     /// ```
     WordForward,
+    /// Move cursor forward to the next end of word. Word boundary appears at spaces, punctuations, and others. For example
+    /// `fn foo(a)` consists of words `fn`, `foo`, `(`, `a`, `)`. When the cursor is at the end of line, it moves to the
+    /// end of the first word of the next line.
+    /// ```
+    /// use tui_textarea::{TextArea, CursorMove};
+    ///
+    /// let mut textarea = TextArea::from(["aaa bbb (c)", " dd"]);
+    ///
+    ///
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (0, 2));
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (0, 6));
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (0, 8));
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (0, 9));
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (0, 10));
+    /// textarea.move_cursor(CursorMove::WordEnd);
+    /// assert_eq!(textarea.cursor(), (1, 2));
+    /// ```
+    WordEnd,
     /// Move cursor backward by one word.  Word boundary appears at spaces, punctuations, and others. For example
     /// `fn foo(a)` consists of words `fn`, `foo`, `(`, `a`, `)`.When the cursor is at the head of line, it moves to
     /// the end of previous line.
@@ -262,6 +285,19 @@ impl CursorMove {
             Bottom => {
                 let row = lines.len() - 1;
                 Some((row, fit_col(col, &lines[row])))
+            }
+            WordEnd => {
+                if let Some(col) = find_word_end_next(&lines[row], col) {
+                    Some((row, col))
+                } else if row + 1 < lines.len() {
+                    if let Some(col) = find_word_end_next(&lines[row + 1], 0) {
+                        Some((row + 1, col))
+                    } else {
+                        Some((row + 1, lines[row + 1].chars().count()))
+                    }
+                } else {
+                    Some((row, lines[row].chars().count()))
+                }
             }
             WordForward => {
                 if let Some(col) = find_word_start_forward(&lines[row], col) {

--- a/src/word.rs
+++ b/src/word.rs
@@ -57,7 +57,7 @@ pub fn find_word_end_next(line: &str, start_col: usize) -> Option<usize> {
         cur_col = next_col;
     }
     // if end of line is whitespace, don't stop the cursor
-    if cur != CharKind::Space && cur_col.saturating_sub(start_col) > 1 {
+    if cur != CharKind::Space && cur_col.saturating_sub(start_col) >= 1 {
         return Some(cur_col);
     }
     None

--- a/src/word.rs
+++ b/src/word.rs
@@ -43,6 +43,26 @@ pub fn find_word_end_forward(line: &str, start_col: usize) -> Option<usize> {
     None
 }
 
+pub fn find_word_end_next(line: &str, start_col: usize) -> Option<usize> {
+    let mut it = line.chars().enumerate().skip(start_col);
+    let (mut cur_col, cur_char) = it.next()?;
+    let mut cur = CharKind::new(cur_char);
+    for (next_col, c) in it {
+        let next = CharKind::new(c);
+        // if cursor started at the end of a word, don't stop
+        if next_col.saturating_sub(start_col) > 1 && cur != CharKind::Space && next != cur {
+            return Some(next_col.saturating_sub(1));
+        }
+        cur = next;
+        cur_col = next_col;
+    }
+    // if end of line is whitespace, don't stop the cursor
+    if cur != CharKind::Space && cur_col.saturating_sub(start_col) > 1 {
+        return Some(cur_col);
+    }
+    None
+}
+
 pub fn find_word_start_backward(line: &str, start_col: usize) -> Option<usize> {
     let idx = line
         .char_indices()

--- a/tests/cursor.rs
+++ b/tests/cursor.rs
@@ -17,6 +17,7 @@ fn empty_textarea() {
         Top,
         Bottom,
         WordForward,
+        WordEnd,
         WordBack,
         ParagraphForward,
         ParagraphBack,


### PR DESCRIPTION
for https://github.com/rhysd/tui-textarea/issues/74; it's a pretty niche use case though, so I understand if it doesn't make sense to merge.

I realized the existing `find_word_end_forward()` doesn't have the same behavior as going to the next end of word in vim, as it instead places the cursor immediately after the last character at the next end of word.

So, I added a `find_word_end_next()`, which more closely emulates the expected behavior (moving the cursor on top of the last character at the next end of word).