### PR TITLE
Improve compatibility of vim example

### DIFF
--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -155,6 +155,22 @@ impl Vim {
                         key: Key::Char('$'),
                         ..
                     } => textarea.move_cursor(CursorMove::End),
+                    Input { // Note: Not sorted with j
+                        key: Key::Char('J'),
+                        ..
+                    } => {
+                        let cursor = textarea.cursor();
+                        textarea.cancel_selection();
+                        textarea.move_cursor(CursorMove::End);
+                        let success = textarea.delete_line_by_end();
+                        if success {
+                            textarea.insert_char(' ');
+                        } else { // In regular vim, joining on the final line is a noop
+                            let (c1, c2) = cursor;
+                            textarea.move_cursor(CursorMove::Jump(c1 as u16, c2 as u16));
+                            // TODO: beep
+                        }
+                    }
                     Input {
                         key: Key::Char('D'),
                         ..

--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -401,6 +401,11 @@ impl Vim {
                     }
                     Input { key: Key::Esc, .. }
                     | Input {
+                        key: Key::Char('['),
+                        ctrl: true,
+                        ..
+                    }
+                    | Input {
                         key: Key::Char('v'),
                         ctrl: false,
                         ..
@@ -500,6 +505,11 @@ impl Vim {
             Mode::Insert => match input {
                 Input { key: Key::Esc, .. }
                 | Input {
+                    key: Key::Char('['),
+                    ctrl: true,
+                    ..
+                }
+                | Input {
                     key: Key::Char('c'),
                     ctrl: true,
                     ..
@@ -511,6 +521,11 @@ impl Vim {
             },
             Mode::Replace(once) => match input {
                 Input { key: Key::Esc, .. }
+                | Input {
+                    key: Key::Char('['),
+                    ctrl: true,
+                    ..
+                }
                 | Input {
                     key: Key::Char('c'),
                     ctrl: true,

--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -212,7 +212,15 @@ impl Vim {
                         ..
                     } => {
                         textarea.cancel_selection();
-                        textarea.move_cursor(CursorMove::Forward);
+
+                        let (cursor_line, cursor_char) = textarea.cursor();
+                        let lines = textarea.lines();
+                        let line = &lines[cursor_line];
+                        let line_length = line.chars().count(); // FIXME: Not acceptable-- O(N)
+
+                        if cursor_char < line_length {
+                            textarea.move_cursor(CursorMove::Forward);
+                        }
                         return Transition::Mode(Mode::Insert);
                     }
                     Input {

--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -95,19 +95,39 @@ impl Vim {
                     Input {
                         key: Key::Char('h'),
                         ..
+                    } |
+                    Input {
+                        key: Key::Left,
+                        ..
                     } => textarea.move_cursor(CursorMove::Back),
+
                     Input {
                         key: Key::Char('j'),
                         ..
+                    } |
+                    Input {
+                        key: Key::Down,
+                        ..
                     } => textarea.move_cursor(CursorMove::Down),
+
                     Input {
                         key: Key::Char('k'),
                         ..
+                    } |
+                    Input {
+                        key: Key::Up,
+                        ..
                     } => textarea.move_cursor(CursorMove::Up),
+
                     Input {
                         key: Key::Char('l'),
                         ..
+                    } |
+                    Input {
+                        key: Key::Right,
+                        ..
                     } => textarea.move_cursor(CursorMove::Forward),
+
                     Input {
                         key: Key::Char('w'),
                         ..

--- a/examples/vim.rs
+++ b/examples/vim.rs
@@ -160,7 +160,7 @@ impl Vim {
                         ..
                     } => {
                         let cursor = textarea.cursor();
-                        textarea.cancel_selection();
+                        textarea.cancel_selection(); // FIXME: WRONG!! J when there is a selection merges the selected lines.
                         textarea.move_cursor(CursorMove::End);
                         let success = textarea.delete_line_by_end();
                         if success {
@@ -245,6 +245,22 @@ impl Vim {
                     } => {
                         textarea.cancel_selection();
                         textarea.move_cursor(CursorMove::End);
+                        return Transition::Mode(Mode::Insert);
+                    }
+                    Input {
+                        key: Key::Char('S'),
+                        ..
+                    } => {
+                        textarea.cancel_selection(); // FIXME: WRONG!! S when there is a selection collapses and clears all lines.
+                        textarea.move_cursor(CursorMove::Head);
+                        let (cursor_line, _) = textarea.cursor();
+                        let lines = textarea.lines();
+                        let line = &lines[cursor_line];
+                        if line.len() > 0 {
+                            // delete_line_by_end has a special behavior where if you are at the end,
+                            // it joins the line with the next. Prevent accidentally triggering this on an empty line.
+                            textarea.delete_line_by_end();
+                        }
                         return Transition::Mode(Mode::Insert);
                     }
                     Input {


### PR DESCRIPTION
The vim example is actually pretty good, and I am using it as the basis of an application. It does have some slight behavior divergences from normal vim, some of which require minimal code to fix.

I have made some changes to make it more vim-like, in three categories:

- Support arrow keys in normal mode
- Fix behavior of `a` and `x` when issued on the final character of a line
- Support `J` in normal and visual mode
- Support `S` in normal and visual mode
- Support `r`/`R` in normal and replace mode
- Support CTRL-`[` as shortcut for ESC (some machines, like my Android tablet, cannot easily type an ESC)

Some notes about these changes:

- Most of the changes are very minimal in their basic form, they are only complicated when visual mode is supported. If they are too complicated and you would prefer the example mode simple, I could just make visual mode "more wrong" by stripping out commits b2ffbfb772a4ca24c8685f31ddb5766f136aed24, 15bbd685e2df2be1fa3e61dfe5405e1782b78430, 43861bfec67ac0ddb95ce826c16fc3ae99d18a01 and then this PR would be very short.
- There is a big incompatibility between normal vim and your "vim" example: In your example, it is possible to move the cursor "one character past" the end of the line in normal mode. In normal vim, this would only be possible in insert mode. I have not attempted to fix this, but if it were fixed, it would obviate my fixes for `a` and `x` and make some of the other code simpler.
- I have also implemented `:` command line mode in a separate branch, but it is very complicated (and my current version uses a parser library), so I am not going to PR this unless you request it.

Thanks!