### PR TITLE
Custom highlight support [WIP]

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -167,7 +167,7 @@ impl<'a> LineHighlighter<'a> {
         start_off: usize,
         end_row: usize,
         end_off: usize,
-        boundary: Boundary
+        boundary: Boundary,
     ) {
         let (start, end) = if current_row == start_row {
             if start_row == end_row {
@@ -185,8 +185,7 @@ impl<'a> LineHighlighter<'a> {
             return;
         };
         if start != end {
-            self.boundaries
-                .push((boundary, start));
+            self.boundaries.push((boundary, start));
             self.boundaries.push((Boundary::End, end));
         }
     }
@@ -199,7 +198,14 @@ impl<'a> LineHighlighter<'a> {
         end_row: usize,
         end_off: usize,
     ) {
-        self.multiline_highlight(current_row, start_row, start_off, end_row, end_off, Boundary::Select(self.select_style));
+        self.multiline_highlight(
+            current_row,
+            start_row,
+            start_off,
+            end_row,
+            end_off,
+            Boundary::Select(self.select_style),
+        );
     }
 
     pub fn custom(
@@ -210,9 +216,16 @@ impl<'a> LineHighlighter<'a> {
         end_row: usize,
         end_off: usize,
         style: Style,
-        priority: u8
-        ) {
-        self.multiline_highlight(current_row, start_row, start_off, end_row, end_off, Boundary::Custom(style, priority));
+        priority: u8,
+    ) {
+        self.multiline_highlight(
+            current_row,
+            start_row,
+            start_off,
+            end_row,
+            end_off,
+            Boundary::Custom(style, priority),
+        );
     }
 
     pub fn into_spans(self) -> Line<'a> {

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -59,7 +59,7 @@ impl fmt::Display for YankText {
 struct CustomHighlight {
     range: ((usize, usize), (usize, usize)),
     style: Style,
-    priority: u8
+    priority: u8,
 }
 
 /// A type to manage state of textarea. These are some important methods:
@@ -132,7 +132,7 @@ pub struct TextArea<'a> {
     mask: Option<char>,
     selection_start: Option<(usize, usize)>,
     select_style: Style,
-    custom_highlights: Vec<CustomHighlight>
+    custom_highlights: Vec<CustomHighlight>,
 }
 
 /// Convert any iterator whose elements can be converted into [`String`] into [`TextArea`]. Each [`String`] element is
@@ -238,7 +238,7 @@ impl<'a> TextArea<'a> {
             mask: None,
             selection_start: None,
             select_style: Style::default().bg(Color::LightBlue),
-            custom_highlights: Default::default()
+            custom_highlights: Default::default(),
         }
     }
 
@@ -1364,8 +1364,17 @@ impl<'a> TextArea<'a> {
         self.selection_start = None;
     }
 
-    pub fn custom_highlight(&mut self, range:((usize, usize), (usize, usize)), style:Style, priority:u8) {
-        self.custom_highlights.push(CustomHighlight { range, style, priority });
+    pub fn custom_highlight(
+        &mut self,
+        range: ((usize, usize), (usize, usize)),
+        style: Style,
+        priority: u8,
+    ) {
+        self.custom_highlights.push(CustomHighlight {
+            range,
+            style,
+            priority,
+        });
     }
 
     pub fn clear_custom_highlight(&mut self) {
@@ -1609,7 +1618,7 @@ impl<'a> TextArea<'a> {
             self.cursor_style,
             self.tab_len,
             self.mask,
-            self.select_style
+            self.select_style,
         );
 
         if let Some(style) = self.line_number_style {
@@ -1629,8 +1638,21 @@ impl<'a> TextArea<'a> {
             hl.selection(row, start.row, start.offset, end.row, end.offset);
         }
 
-        for CustomHighlight { range:((start_row, start_offset), (end_row, end_offset)), style, priority } in &self.custom_highlights {
-            hl.custom(row, *start_row, *start_offset, *end_row, *end_offset, *style, *priority);
+        for CustomHighlight {
+            range: ((start_row, start_offset), (end_row, end_offset)),
+            style,
+            priority,
+        } in &self.custom_highlights
+        {
+            hl.custom(
+                row,
+                *start_row,
+                *start_offset,
+                *end_row,
+                *end_offset,
+                *style,
+                *priority,
+            );
         }
 
         hl.into_spans()


### PR DESCRIPTION
My attempt at #87 .

This adds new public functions to TextArea:

```rust
pub fn custom_highlight(
    &mut self,
    range: ((usize, usize), (usize, usize)),
    style: Style,
    priority: u8,
);

pub fn clear_custom_highlight(&mut self);
```

This works, I'm actually already using it in [a working program](https://github.com/mcclure/tui-textarea/tree/ami) (while prototyping this lives in that repo as `cargo run --example vim`). However, there are two high-level issues:

1. I need feedback as to whether you like this API or whether you'd be more likely to accept a different one. The "priority" in particular is really iffy. I (see highlight.rs:26) changed the existing priorities to 10, 20, 30, so there's lots of space between them, but that seems… I mean, it works, but it might be awkward if you add more builtins later and have to populate the priorities in between.

2. This code makes it really easy to create "overlapping regions". Textarea currently fails on this because it treats "end" like a stack. I don't believe this is a problem with this PR but a problem with the underlying code, as I think(?) I can recreate it by creating a search and a highlight at the same time (see my note in #87).

But look what happens when you try to use this patch:

[Screencast from 2024-12-08 20-17-29.webm](https://github.com/user-attachments/assets/4f09c6b4-a17f-4a6c-abe8-65e1255c9070)

This program (the "ami" prototype I linked above) lets you input a song in a little music "programming language". If there is anything it doesn't recognize (basically anything other than a number) it highlights the first bad character in red. To test ranges, I changed the code so instead of highlighting one character it highlights the entire row after the highlighted character. There are two bad things I see here: One, the final character of the line is blue, and I don't know why; two, when the cursor starts overlapping (underlapping, the cursor priority is 30 and the error priority is 35) everything freaks out.

Minor issues: I haven't written tests yet, but if you tell me an external API you're happy with, I can do that; there is an outstanding clippy, an IMO spurious one (there's an eight-argument function and it thinks 7 should be the limit), I could refactor that but again want to know what final external API I'm targeting.