### PR TITLE
don't consider underscores as punctuation

### DIFF
--- a/src/word.rs
+++ b/src/word.rs
@@ -9,6 +9,8 @@ impl CharKind {
     fn new(c: char) -> Self {
         if c.is_whitespace() {
             Self::Space
+        } else if c == '_' {
+            Self::Other
         } else if c.is_ascii_punctuation() {
             Self::Punct
         } else {


### PR DESCRIPTION
underscores are usually not treated as punctuation by web input fields or editors when moving the cursor to the end of a word or start of a word. for example, using [e] in nvim or [alt + ➡️] in an input will take the cursor across this entire string at once: here_to_here