### PR TITLE
Modified flag does not work with editor examples

### DIFF
--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -338,7 +338,7 @@ impl Editor<'_> {
                     }
                     input => {
                         let buffer = &mut self.buffers[self.current];
-                        buffer.modified = buffer.textarea.input(input);
+                        buffer.modified |= buffer.textarea.input(input);
                     }
                 }
             }

--- a/examples/tuirs_editor.rs
+++ b/examples/tuirs_editor.rs
@@ -341,7 +341,7 @@ impl Editor<'_> {
                     }
                     input => {
                         let buffer = &mut self.buffers[self.current];
-                        buffer.modified = buffer.textarea.input(input);
+                        buffer.modified |= buffer.textarea.input(input);
                     }
                 }
             }


### PR DESCRIPTION
 fix(examples/editor modified): Modified flag does not work with editor and tuirs_editor examples.

Fixes: #99