### PR TITLE
update ratatui, crossterm and termwiz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ include = ["/src", "/examples", "/tests", "/README.md", "/LICENSE.txt"]
 [features]
 default = ["crossterm"]
 # Features to use ratatui
-ratatui = ["dep:ratatui"]
-crossterm = ["ratatui", "dep:crossterm", "ratatui/crossterm"]
-termion = ["ratatui", "dep:termion", "ratatui/termion"]
-termwiz = ["ratatui", "dep:termwiz", "ratatui/termwiz"]
+ratatui = ["dep:ratatui-core", "dep:ratatui-widgets"]
+crossterm = ["ratatui", "dep:crossterm"]
+crossterm_0_28 = ["ratatui", "dep:crossterm-028"]
+termion = ["ratatui", "dep:termion"]
+termwiz = ["ratatui", "dep:termwiz"]
 no-backend = ["ratatui"]
 # Features to use tui-rs
 tuirs = ["dep:tui"]
@@ -36,13 +37,15 @@ arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }
-crossterm = { package = "crossterm", version = "0.28", optional = true }
+crossterm = { package = "crossterm", version = "0.29", optional = true }
+crossterm-028 = { package = "crossterm", version = "0.28", optional = true }
 crossterm-025 = { package = "crossterm", version = "0.25", optional = true }
-ratatui = { version = "0.29.0", default-features = false, optional = true }
+ratatui-core = { version = "0.1.0", default-features = false, optional = true }
+ratatui-widgets = { version = "0.3.0", default-features = false, optional = true }
 regex = { version = "1", optional = true }
 termion = { version = "4.0", optional = true }
 termion-15 = { package = "termion", version = "1.5", optional = true }
-termwiz = { version = "0.22.0", optional = true }
+termwiz = { version = "0.23.0", optional = true }
 tui = { version = "0.19", default-features = false, optional = true }
 unicode-width = "0.2.0"
 serde = { version = "1", optional = true , features = ["derive"] }
@@ -107,6 +110,8 @@ lto = "thin"
 
 [dev-dependencies]
 serde_json = "1.0.120"
+# Ratatui with all backends enabled for tests and examples
+ratatui = {version = "0.30.0", features=["crossterm", "termion", "termwiz"]} # Used by examples
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,7 +10,7 @@ bench = false
 
 [dependencies]
 tui-textarea = { path = "..", features = ["no-backend", "search"] }
-ratatui = { version = "0.29.0", default-features = false }
+ratatui = { version = "0.30.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -4,6 +4,7 @@
 use ratatui::backend::{Backend, WindowSize};
 use ratatui::buffer::Cell;
 use ratatui::layout::{Position, Size};
+use ratatui::prelude::backend::ClearType;
 use ratatui::Terminal;
 use std::io;
 use tui_textarea::TextArea;
@@ -40,6 +41,8 @@ impl Default for DummyBackend {
 }
 
 impl Backend for DummyBackend {
+    type Error = io::Error;
+
     #[inline]
     fn draw<'a, I>(&mut self, _content: I) -> io::Result<()>
     where
@@ -71,6 +74,11 @@ impl Backend for DummyBackend {
 
     #[inline]
     fn clear(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
+    fn clear_region(&mut self, _clear_type: ClearType) -> io::Result<()> {
         Ok(())
     }
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -2,7 +2,7 @@ use crate::ratatui::style::Style;
 use crate::ratatui::text::Span;
 use crate::util::{num_digits, spaces};
 #[cfg(feature = "ratatui")]
-use ratatui::text::Line;
+use ratatui_core::text::Line;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::iter;

--- a/src/history.rs
+++ b/src/history.rs
@@ -61,7 +61,7 @@ impl EditKind {
                 // Remove middle lines of chunk
                 let mut last_line = lines
                     .drain(after.row + 1..after.row + c.len())
-                    .last()
+                    .next_back()
                     .unwrap();
                 // Remove last line of chunk
                 last_line.drain(..c[c.len() - 1].len());

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,4 +1,8 @@
-#[cfg(any(feature = "crossterm", feature = "tuirs-crossterm"))]
+#[cfg(any(
+    feature = "crossterm",
+    feature = "crossterm_0_28",
+    feature = "tuirs-crossterm"
+))]
 mod crossterm;
 #[cfg(any(feature = "termion", feature = "tuirs-termion"))]
 mod termion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,25 @@ mod word;
 
 #[cfg(feature = "ratatui")]
 #[allow(clippy::single_component_path_imports)]
-use ratatui;
+mod ratatui {
+    // Best effort to reproduce ratatui 0.29 module layout to keep compatibility with tui module layout
+    pub use ratatui_core::{buffer, layout, style, text};
+    pub mod widgets {
+        pub use ratatui_core::widgets::*;
+        pub use ratatui_widgets::{block::Block, paragraph::Paragraph};
+    }
+}
 #[cfg(feature = "tuirs")]
 use tui as ratatui;
 
-#[cfg(feature = "crossterm")]
+#[cfg(all(feature = "crossterm", not(feature = "crossterm_0_28")))]
 #[allow(clippy::single_component_path_imports)]
 use crossterm;
 #[cfg(feature = "tuirs-crossterm")]
 use crossterm_025 as crossterm;
+#[cfg(feature = "crossterm_0_28")]
+#[allow(clippy::single_component_path_imports)]
+use crossterm_028 as crossterm;
 
 #[cfg(feature = "termion")]
 #[allow(clippy::single_component_path_imports)]

--- a/src/textarea.rs
+++ b/src/textarea.rs
@@ -12,7 +12,7 @@ use crate::util::{spaces, Pos};
 use crate::widget::Viewport;
 use crate::word::{find_word_exclusive_end_forward, find_word_start_backward};
 #[cfg(feature = "ratatui")]
-use ratatui::text::Line;
+use ratatui_core::text::Line;
 use std::cmp::Ordering;
 use std::fmt;
 #[cfg(feature = "tuirs")]
@@ -78,8 +78,8 @@ impl fmt::Display for YankText {
 /// println!("Lines: {:?}", textarea.lines());
 /// ```
 ///
-/// It implements [`ratatui::widgets::Widget`] trait so it can be rendered to a terminal screen via
-/// [`ratatui::Frame::render_widget`] method.
+/// It implements [`ratatui_core::widgets::Widget`] trait so it can be rendered to a terminal screen via
+/// [`ratatui_core::terminal::Frame::render_widget`] method.
 /// ```no_run
 /// use ratatui::backend::CrosstermBackend;
 /// use ratatui::layout::{Constraint, Direction, Layout};
@@ -1616,7 +1616,7 @@ impl<'a> TextArea<'a> {
     }
 
     /// Build a ratatui (or tui-rs) widget to render the current state of the textarea. The widget instance returned
-    /// from this method can be rendered with [`ratatui::Frame::render_widget`].
+    /// from this method can be rendered with [`ratatui_core::terminal::Frame::render_widget`].
     ///
     /// This method was deprecated at v0.5.3 and is no longer necessary. Instead you can directly pass `&TextArea`
     /// reference to the `Frame::render_widget` method call.

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -5,7 +5,7 @@ use crate::ratatui::widgets::{Paragraph, Widget};
 use crate::textarea::TextArea;
 use crate::util::num_digits;
 #[cfg(feature = "ratatui")]
-use ratatui::text::Line;
+use ratatui_core::text::Line;
 use std::cmp;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "tuirs")]


### PR DESCRIPTION
* switch ratatui to backend agnostic ratatui-core and ratatui-widgets crates
* update crossterm to v0.29
* add crossterm_0_28 feature as a fallback to previous crossterm release
* update termwiz to v0.23

Continuing work started in #117 

See also #115 